### PR TITLE
Add accented characters to dumb quote replacement regex

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+openpyxl

--- a/translations/test_translate_survey.py
+++ b/translations/test_translate_survey.py
@@ -1,0 +1,37 @@
+import unittest
+
+from translate_survey import dumb_to_smart_quotes
+
+class TestDumbToSmartQuotes(unittest.TestCase):
+
+    def test_dumb_to_smart_quotes_welsh_single(self):
+        original_text = '''sy'n ymweld â'r Deyrnas Unedig'''
+        expected = '''sy’n ymweld â’r Deyrnas Unedig'''
+
+        actual = dumb_to_smart_quotes(original_text)
+
+        self.assertNotEqual(actual, original_text)
+        self.assertEqual(actual, expected)
+
+    def test_dumb_to_smart_quotes_english_single(self):
+        original_text = '''you're sure he'd said that 'quoting a few words' gave 'smart' quotes?'''
+        expected = '''you’re sure he’d said that ‘quoting a few words’ gave ‘smart’ quotes?'''
+
+        actual = dumb_to_smart_quotes(original_text)
+
+        self.assertNotEqual(actual, original_text)
+        self.assertEqual(actual, expected)
+
+    @unittest.expectedFailure
+    def test_dumb_to_smart_quotes_english_double(self):
+        # Double quotes not supported yet...
+        original_text = '''here is "a sentance with" double dumb "quotes" in the middle'''
+        expected = '''here is “a sentance with” double dumb “quotes” in the middle'''
+
+        actual = dumb_to_smart_quotes(original_text)
+
+        self.assertNotEqual(actual, original_text)
+        self.assertEqual(actual, expected)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/translations/translate_survey.py
+++ b/translations/translate_survey.py
@@ -25,7 +25,7 @@ def dumb_to_smart_quotes(string):
 
     # Find dumb single quotes coming directly after letters or punctuation,
     # and replace them with right single quotes.
-    string = re.sub(r"([a-zA-Z0-9.,?!;:\"\'])'", r'\1’', string)
+    string = re.sub(r"([\w.,?!;:\"\'])'", r'\1’', string)
     # Find any remaining dumb single quotes and replace them with
     # left single quotes.
     string = string.replace("'", '‘')


### PR DESCRIPTION
Adds accented characters to the regex for dumb to smart quote replacement. This fix means dumb quotes that follow an accented character are converted to the right kind of smart quote.

Once merged the Census Household schema can be regenerated to fix https://github.com/ONSdigital/eq-survey-runner/issues/774