### PR TITLE
modify translation directories

### DIFF
--- a/scripts/run_translate_all_surveys.sh
+++ b/scripts/run_translate_all_surveys.sh
@@ -14,7 +14,7 @@ function translate_all_schemas {
         schema=${BASH_REMATCH[1]};
         country_code=${BASH_REMATCH[2]};
         mkdir -p "${path_to_schemas}"/"${country_code}"
-        "${parent_dir_path}"/scripts/run_translate_survey.sh "${path_to_schemas}"/"${schema}".json "${parent_dir_path}"/translations/"${schema}"_translate_"${country_code}".xlsx "${path_to_schemas}"/"${country_code}"
+        "${parent_dir_path}"/scripts/run_translate_survey.sh "${path_to_schemas}"/en/"${schema}".json "${parent_dir_path}"/translations/"${schema}"_translate_"${country_code}".xlsx "${path_to_schemas}"/"${country_code}"
       fi
     done < <(find "${parent_dir_path}"/translations -name "*.xlsx" -exec basename {} \;)
 }


### PR DESCRIPTION
### What is the context of this PR?
-  Changed source directory from "${path_to_schemas}"/ to "${path_to_schemas}"/en/...
- Related pull request https://github.com/ONSdigital/eq-survey-runner/pull/1105

### How to review 
- Checkout above pull request with updated directories
- Git clone eq-translations into directory
- cd into eq-translations and checkout 'eq-1059-moved-directory'
- Run ./scripts/run_translate_all_surveys.sh (and path-to-schemas [projects/eq-survey-runner/data) and check translations are working


