### PR TITLE
Fix duplicate label extraction issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,10 @@ Should be prefixed with the name of the schema to translate followed by `_transl
 
 ```
 census_household_translate_cy.po
+```
+
+## Managing translations
+
+When `gettext` is installed there are a number of command line utilities that can help with managing translations.
+
+To merge the translations from an already translated survey into another one, you can use `msgmerge`. For example `msgmerge census_household-cy.po census_individual.pot > census_individual-cy.po` will merge matching Welsh translations from the Census household questionnaire into the Census individual questionnaire.

--- a/app/survey_schema.py
+++ b/app/survey_schema.py
@@ -13,7 +13,6 @@ class SurveySchema:
         'hide_guidance',
         'description',
         'legal_basis',
-        'label',
     ]
 
     @staticmethod


### PR DESCRIPTION
Labels were being duplicated in the pot template as they were being extracted as part of the no context keys and as part of answers. This pull request fixes the issue so that labels are only extracted as part of answers. 

## How to test
- Run an extraction and check that answer labels are not duplicated in the generated pot file