### PR TITLE
Ensure placeholders do not update structure

### DIFF
--- a/app/survey_schema.py
+++ b/app/survey_schema.py
@@ -13,22 +13,8 @@ class SurveySchema:
         'hide_guidance',
         'description',
         'legal_basis',
+        'text',
     ]
-
-    @staticmethod
-    def resolve(schema, message_pointer):
-        """
-        Parse the location of the schema at message pointer.
-
-        If the value at location *message_pointer* is a dict,
-        correctly parse and return the value.
-        """
-        resolved = resolve_pointer(schema, message_pointer)
-
-        try:
-            return resolved['text']
-        except (KeyError, TypeError):
-            return resolved
 
     def __init__(self, schema_data=None):
         self.schema = schema_data
@@ -100,7 +86,7 @@ class SurveySchema:
 
     def get_title_pointers(self):
         """
-        Titles need to be handled seperately as they may require context for translation
+        Titles need to be handled separately as they may require context for translation
         :return:
         """
         return find_pointers_to(self.schema, 'title')
@@ -113,7 +99,7 @@ class SurveySchema:
         return find_pointers_to(self.schema, 'label')
 
     def get_parent_id(self, pointer):
-        resolved_data = self.resolve(self.schema, pointer)
+        resolved_data = resolve_pointer(self.schema, pointer)
 
         if isinstance(resolved_data, dict) and 'id' in resolved_data:
             return resolved_data['id']
@@ -131,7 +117,7 @@ class SurveySchema:
 
     def get_parent_question(self, pointer):
         question_pointer = self.get_parent_question_pointer(pointer)
-        return self.resolve(self.schema, question_pointer + '/title')
+        return resolve_pointer(self.schema, question_pointer + '/title')
 
     def get_catalog(self):
         """
@@ -141,12 +127,12 @@ class SurveySchema:
         total_translations = len(self.no_context_pointers + self.context_pointers)
 
         for pointer in self.no_context_pointers:
-            pointer_contents = self.resolve(self.schema, pointer)
+            pointer_contents = resolve_pointer(self.schema, pointer)
             if pointer_contents:
                 catalog.add(dumb_to_smart_quotes(pointer_contents))
 
         for pointer in self.context_pointers:
-            pointer_contents = self.resolve(self.schema, pointer)
+            pointer_contents = resolve_pointer(self.schema, pointer)
             if pointer_contents:
                 parent_answer_id = self.get_parent_id(pointer)
                 question = self.get_parent_question(pointer)
@@ -176,7 +162,7 @@ class SurveySchema:
         missing_translations = 0
 
         for pointer in self.no_context_pointers:
-            pointer_contents = self.resolve(self.schema, pointer)
+            pointer_contents = resolve_pointer(self.schema, pointer)
             translation = schema_translation.translate_message(pointer_contents)
             if translation:
                 translated_schema = set_pointer(translated_schema, pointer, translation)
@@ -187,7 +173,7 @@ class SurveySchema:
                 )
 
         for pointer in self.context_pointers:
-            pointer_contents = self.resolve(self.schema, pointer)
+            pointer_contents = resolve_pointer(self.schema, pointer)
             parent_answer_id = self.get_parent_id(pointer)
             translation = schema_translation.translate_message(
                 pointer_contents, parent_answer_id

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,6 +1,10 @@
 import re
 
 
+def is_placeholder(input_data):
+    return 'placeholders' in input_data
+
+
 def find_pointers_containing(input_data, search_key, pointer=None):
     """
     Recursive function which lists pointers which contain a search key
@@ -10,10 +14,10 @@ def find_pointers_containing(input_data, search_key, pointer=None):
     :return: generator of the json pointer paths
     """
     if isinstance(input_data, dict):
-        if pointer and search_key in input_data:
+        if pointer and search_key in input_data and not is_placeholder(input_data[search_key]):
             yield pointer
         for k, v in input_data.items():
-            if isinstance(v, dict) and search_key in v:
+            if isinstance(v, dict) and search_key in v and not is_placeholder(v[search_key]):
                 yield pointer + '/' + k if pointer else '/' + k
             else:
                 yield from find_pointers_containing(v, search_key, pointer + '/' + k if pointer else '/' + k)
@@ -29,7 +33,7 @@ def find_pointers_to(input_data, search_key):
     :param search_key: the key to search for
     :return: list of the json pointer paths
     """
-    root_pointers = ['/{}'.format(search_key)] if search_key in input_data else []
+    root_pointers = ['/{}'.format(search_key)] if search_key in input_data and not is_placeholder(input_data[search_key]) else []
     pointer_iterator = find_pointers_containing(input_data, search_key)
     return root_pointers + ['{}/{}'.format(p, search_key) for p in pointer_iterator]
 

--- a/tests/test_survey_schema.py
+++ b/tests/test_survey_schema.py
@@ -458,5 +458,128 @@ class TestTranslate(unittest.TestCase):
 
         assert "What is ‘this persons’ date of birth?" in actual_items
 
+    def test_find_pointers_ignores_placeholders(self):
+        schema = SurveySchema({
+            "id": "establishment-position-question",
+            "title": {
+                "placeholders": [
+                    {
+                        "placeholder": "person_name_possessive",
+                        "transforms": [
+                            {
+                                "arguments": {
+                                    "delimiter": " ",
+                                    "list_to_concatenate": {
+                                        "identifier": [
+                                            "first-name",
+                                            "last-name"
+                                        ],
+                                        "source": "answers"
+                                    }
+                                },
+                                "transform": "concatenate_list"
+                            },
+                            {
+                                "arguments": {
+                                    "string_to_format": {
+                                        "source": "previous_transform"
+                                    }
+                                },
+                                "transform": "format_possessive"
+                            }
+                        ]
+                    }
+                ],
+                "text": "What is <em>{person_name_possessive}</em> position in this establishment?"
+            },
+            "type": "General"
+        })
+        pointers = schema.get_title_pointers()
 
+        assert '/title' not in pointers
 
+    def test_placeholder_translation(self):
+
+        schema_translation = SchemaTranslation()
+
+        catalog = Catalog()
+
+        catalog.add("What is <em>{person_name_possessive}</em> position in this establishment?",
+                    "WELSH - What is <em>{person_name_possessive}</em> position in this establishment?")
+
+        schema_translation.catalog = catalog
+
+        schema = SurveySchema({
+            "id": "establishment-position-question",
+            "title": {
+                "placeholders": [
+                    {
+                        "placeholder": "person_name_possessive",
+                        "transforms": [
+                            {
+                                "arguments": {
+                                    "delimiter": " ",
+                                    "list_to_concatenate": {
+                                        "identifier": [
+                                            "first-name",
+                                            "last-name"
+                                        ],
+                                        "source": "answers"
+                                    }
+                                },
+                                "transform": "concatenate_list"
+                            },
+                            {
+                                "arguments": {
+                                    "string_to_format": {
+                                        "source": "previous_transform"
+                                    }
+                                },
+                                "transform": "format_possessive"
+                            }
+                        ]
+                    }
+                ],
+                "text": "What is <em>{person_name_possessive}</em> position in this establishment?"
+            },
+            "type": "General"
+        })
+        translated = schema.translate(schema_translation)
+
+        expected = {
+            "id": "establishment-position-question",
+            "title": {
+                "placeholders": [
+                    {
+                        "placeholder": "person_name_possessive",
+                        "transforms": [
+                            {
+                                "arguments": {
+                                    "delimiter": " ",
+                                    "list_to_concatenate": {
+                                        "identifier": [
+                                            "first-name",
+                                            "last-name"
+                                        ],
+                                        "source": "answers"
+                                    }
+                                },
+                                "transform": "concatenate_list"
+                            },
+                            {
+                                "arguments": {
+                                    "string_to_format": {
+                                        "source": "previous_transform"
+                                    }
+                                },
+                                "transform": "format_possessive"
+                            }
+                        ]
+                    }
+                ],
+                "text": "WELSH - What is <em>{person_name_possessive}</em> position in this establishment?"
+            },
+            "type": "General"
+        }
+
+        assert expected == translated.schema


### PR DESCRIPTION
**Context**

The translation process currently updates placeholders to be a translated string, rather than a translated json structure. This means that the placeholder won't be resolved within a translated survey.

**Changes**

Update pointer search to ignore keys which contain placeholders and instead extract the text of them separately.

**To Test**

Run pytest and confirm the new unit tests pass.