### PR TITLE
Ensure placeholders with and without context are found correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,6 @@ census_household_translate_cy.po
 
 When `gettext` is installed there are a number of command line utilities that can help with managing translations.
 
-To merge the translations from an already translated survey into another one, you can use `msgmerge`. For example `msgmerge census_household-cy.po census_individual.pot > census_individual-cy.po` will merge matching Welsh translations from the Census household questionnaire into the Census individual questionnaire.
+To merge the translations from an already translated survey into another one, you can use `msgmerge`. For example `msgmerge census_household-cy.po census_individual.pot -o census_individual-cy.po` will merge matching Welsh translations from the Census household questionnaire into the Census individual questionnaire.
+
+To add the content of translation files together, you can use `msgcat`. For example `msgcat census_individual-wls.pot census_individual-gb.pot -o census_individual.pot` will add unique messages from each input template file to create an output Census individual template for both versions.

--- a/tests/test_survey_schema.py
+++ b/tests/test_survey_schema.py
@@ -498,6 +498,148 @@ class TestTranslate(unittest.TestCase):
 
         assert '/title' not in pointers
 
+    def test_get_placeholder_pointers(self):
+        schema = SurveySchema({
+           "question": {
+              "answers": [
+                 {
+                    "id": "term-time-location-answer",
+                    "mandatory": True,
+                    "options": [
+                       {
+                          "label": {
+                             "placeholders": [
+                                {
+                                   "placeholder": "address",
+                                   "value": {
+                                      "identifier": "display_address",
+                                      "source": "metadata"
+                                   }
+                                }
+                             ],
+                             "text": "{address}"
+                          },
+                          "value": "household-address"
+                       },
+                       {
+                          "label": {
+                             "placeholders": [
+                                {
+                                   "placeholder": "country",
+                                   "value": {
+                                      "identifier": "another-address-answer-other-country",
+                                      "source": "answers"
+                                   }
+                                }
+                             ],
+                             "text": "The address in {country}"
+                          },
+                          "value": "30-day-address"
+                       },
+                       {
+                          "label": "Another address",
+                          "value": "Another address"
+                       }
+                    ],
+                    "type": "Radio"
+                 }
+              ],
+              "id": "term-time-location-question",
+              "title": {
+                 "placeholders": [
+                    {
+                       "placeholder": "person_name",
+                       "transforms": [
+                          {
+                             "arguments": {
+                                "delimiter": " ",
+                                "list_to_concatenate": {
+                                   "identifier": [
+                                      "first-name",
+                                      "last-name"
+                                   ],
+                                   "source": "answers"
+                                }
+                             },
+                             "transform": "concatenate_list"
+                          }
+                       ]
+                    }
+                 ],
+                 "text": "During term time, where does <em>{person_name}</em> usually live?"
+              },
+              "type": "General"
+            }
+        })
+
+        assert '/question/answers/0/options/0/label/text' in schema.context_placeholder_pointers
+        assert '/question/answers/0/options/1/label/text' in schema.context_placeholder_pointers
+        assert '/question/title/text' in schema.no_context_placeholder_pointers
+
+    def test_placeholder_catalog_context(self):
+        schema = SurveySchema({
+           "question": {
+              "answers": [
+                 {
+                    "id": "term-time-location-answer",
+                    "mandatory": True,
+                    "options": [
+                       {
+                          "label": {
+                             "placeholders": [
+                                {
+                                   "placeholder": "address",
+                                   "value": {
+                                      "identifier": "display_address",
+                                      "source": "metadata"
+                                   }
+                                }
+                             ],
+                             "text": "{address}"
+                          },
+                          "value": "household-address"
+                       },
+                       {
+                          "label": "Another address",
+                          "value": "Another address"
+                       }
+                    ],
+                    "type": "Radio"
+                 }
+              ],
+              "id": "term-time-location-question",
+              "title": {
+                 "placeholders": [
+                    {
+                       "placeholder": "person_name",
+                       "transforms": [
+                          {
+                             "arguments": {
+                                "delimiter": " ",
+                                "list_to_concatenate": {
+                                   "identifier": [
+                                      "first-name",
+                                      "last-name"
+                                   ],
+                                   "source": "answers"
+                                }
+                             },
+                             "transform": "concatenate_list"
+                          }
+                       ]
+                    }
+                 ],
+                 "text": "During term time, where does <em>{person_name}</em> usually live?"
+              },
+              "type": "General"
+            }
+        })
+
+        message = schema.get_catalog().get(
+            '{address}', 'Answer for: During term time, where does <em>{person_name}</em> usually live?'
+        )
+        assert message.auto_comments == ['answer-id: term-time-location-answer']
+
     def test_placeholder_translation(self):
 
         schema_translation = SchemaTranslation()


### PR DESCRIPTION
### What is the context of this PR?

The [previous placeholder extraction](https://github.com/ONSdigital/eq-translations/pull/28) wrongly assumed that placeholders would never require context (i.e Be part of an answer). This change seeks to correct that. 

Instead of searching for placeholders using the 'text' key as part of a no_context key search, it searches for placeholders and filters them into separate lists dependant on whether they require context.

### How to review?

The new unit test (taken from census individual) includes keys that require both context and don't so should now cover both use cases. See if you agree with the approach.