### PR TITLE
Fix pointer location

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -10,17 +10,14 @@ def find_pointers_containing(input_data, search_key, pointer=None):
     Recursive function which lists pointers which contain a search key
     :param input_data: the input data to search
     :param search_key: the key to search for
-    :param pointer: the key to search for
+    :param pointer: the current pointer
     :return: generator of the json pointer paths
     """
     if isinstance(input_data, dict):
         if pointer and search_key in input_data and not is_placeholder(input_data[search_key]):
             yield pointer
         for k, v in input_data.items():
-            if isinstance(v, dict) and search_key in v and not is_placeholder(v[search_key]):
-                yield pointer + '/' + k if pointer else '/' + k
-            else:
-                yield from find_pointers_containing(v, search_key, pointer + '/' + k if pointer else '/' + k)
+            yield from find_pointers_containing(v, search_key, pointer + '/' + k if pointer else '/' + k)
     elif isinstance(input_data, list):
         for index, item in enumerate(input_data):
             yield from find_pointers_containing(item, search_key, '{}/{}'.format(pointer, index))

--- a/tests/test_survey_schema.py
+++ b/tests/test_survey_schema.py
@@ -7,13 +7,60 @@ from app.survey_schema import SurveySchema
 
 
 class TestSurveySchema(unittest.TestCase):
-    def test_variant(self):
-        schema = SurveySchema({
-            "question_variants": [{
+    schema = SurveySchema({
+        "question_variants": [{
+            "question": {
+                "type": "General",
+                "id": "question-2",
+                "title": "What is 'this persons' date of birth?",
+                "answers": [
+                    {
+                        "id": "confirm-feeling-answer",
+                        "type": "Radio",
+                        "label": "confirm",
+                        "mandatory": True,
+                        "options": [
+                            {
+                                "value": "Yes",
+                                "label": "Yes"
+                            },
+                            {
+                                "value": "No",
+                                "label": "No"
+                            }
+                        ]
+                    }
+                ],
+                "guidance": {
+                    "content": [
+                        {
+                            "title": "Include:",
+                            "list": [
+                                "all employees in Great Britain (England, Scotland and Wales), both full and part-time, who received pay in the relevant period"
+                            ]
+                        },
+                        {
+                            "title": "Exclude:",
+                            "list": [
+                                "trainees on government schemes",
+                                "employees working abroad unless paid directly from this business’s GB payroll",
+                                "employees in Northern Ireland"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "when": {
+                "id": "feeling-answer",
+                "condition": "equals",
+                "value": "good"
+            }
+        },
+            {
                 "question": {
                     "type": "General",
                     "id": "question-2",
-                    "title": "What is 'this persons' date of birth?",
+                    "title": "What is your date of birth?",
                     "answers": [
                         {
                             "id": "confirm-feeling-answer",
@@ -54,65 +101,19 @@ class TestSurveySchema(unittest.TestCase):
                 "when": {
                     "id": "feeling-answer",
                     "condition": "equals",
-                    "value": "good"
-                }
-            },
-            {
-                "question": {
-                    "type": "General",
-                    "id": "question-2",
-                    "title": "What is your date of birth?"
-                },
-                "answers": [
-                    {
-                        "id": "confirm-feeling-answer",
-                        "type": "Radio",
-                        "label": "confirm",
-                        "mandatory": True,
-                        "options": [
-                            {
-                                "value": "Yes",
-                                "label": "Yes"
-                            },
-                            {
-                                "value": "No",
-                                "label": "No"
-                            }
-                        ]
-                    }
-                ],
-                "guidance": {
-                    "content": [
-                        {
-                            "title": "Include:",
-                            "list": [
-                                "all employees in Great Britain (England, Scotland and Wales), both full and part-time, who received pay in the relevant period"
-                            ]
-                        },
-                        {
-                            "title": "Exclude:",
-                            "list": [
-                                "trainees on government schemes",
-                                "employees working abroad unless paid directly from this business’s GB payroll",
-                                "employees in Northern Ireland"
-                            ]
-                        }
-                    ]
-                },
-                "when": {
-                     "id": "feeling-answer",
-                     "condition": "equals",
-                     "value": "bad"
+                    "value": "bad"
                 }
             }]
-        })
+    })
 
-        pointers = schema.get_title_pointers()
+    pointers = schema.get_title_pointers()
 
-        assert '/question_variants/0/question/title' in pointers
-        assert '/question_variants/1/question/title' in pointers
-        assert '/question_variants/1/guidance/content/0/title' in pointers
-        assert '/question_variants/1/guidance/content/1/title' in pointers
+    assert '/question_variants/0/question/title' in pointers
+    assert '/question_variants/1/question/title' in pointers
+    assert '/question_variants/0/question/guidance/content/0/title' in pointers
+    assert '/question_variants/0/question/guidance/content/1/title' in pointers
+    assert '/question_variants/1/question/guidance/content/0/title' in pointers
+    assert '/question_variants/1/question/guidance/content/1/title' in pointers
 
     def test_get_messages(self):
         schema = SurveySchema()
@@ -125,7 +126,10 @@ class TestSurveySchema(unittest.TestCase):
             "sections": [{
                 "type": "CalculatedSummary",
                 "id": "block-3",
-                "title": "Calculated Summary Main Title Block 2", "calculation": { "calculation_type": "sum", "answers_to_calculate": [
+                "title": "Calculated Summary Main Title Block 2",
+                "calculation": {
+                    "calculation_type": "sum",
+                    "answers_to_calculate": [
                         "first-number-answer",
                         "second-number-answer"
                     ],


### PR DESCRIPTION
### Context

In certain cases, the current pointer extraction yields the first pointer it finds for a dict, rather than searching through all possible pointers in its sub json structures.

### Changes

Correct relevant tests to ensure all possible pointers are returned.

### How to test

The amended test should fail in v3 and pass on the PR branch.