### PR TITLE
Add a script for Comparing Schemas

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -1,6 +1,48 @@
 import re
 
 
+def list_pointers(input_data, pointer=None):
+    """
+    Recursive function which lists all available pointers in a json structure
+    :param input_data: the input data to search
+    :param pointer: the current pointer
+    :return: generator of the json pointer paths
+    """
+    if isinstance(input_data, dict) and input_data:
+        for k, v in input_data.items():
+            yield pointer + '/' + k if pointer else '/' + k
+            yield from list_pointers(v, pointer + '/' + k if pointer else '/' + k)
+    elif isinstance(input_data, list) and input_data:
+        for index, item in enumerate(input_data):
+            yield '{}/{}'.format(pointer, index) if pointer else '/{}'.format(index)
+            yield from list_pointers(item, '{}/{}'.format(pointer, index))
+
+
+def compare_schemas(source_schema, target_schema):
+    """
+    Compare the pointers in two json structures and return differences
+    :param source_schema: Structure to identify differences against
+    :param target_schema: Target structure to compare against
+    :return:
+    """
+    source_survey_pointers = set(list_pointers(source_schema))
+    target_survey_pointers = set(list_pointers(target_schema))
+
+    missing_target_pointers = source_survey_pointers.difference(target_survey_pointers)
+    missing_source_pointers = target_survey_pointers.difference(source_survey_pointers)
+
+    missing_pointers = missing_target_pointers | missing_source_pointers
+
+    for list_pointer in missing_pointers:
+        print("Missing Pointer: {}".format(list_pointer))
+
+    print("\nTotal attributes in source schema: {}".format(len(source_survey_pointers)))
+    print("Total attributes in target schema: {}".format(len(target_survey_pointers)))
+    print("Differences between source/target schema attributes: {} ".format(len(missing_pointers)))
+
+    return missing_pointers
+
+
 def is_placeholder(input_data):
     return 'placeholders' in input_data
 

--- a/cli/compare_schemas.py
+++ b/cli/compare_schemas.py
@@ -1,0 +1,34 @@
+import argparse
+import os
+
+from app.utils import compare_schemas
+from app.survey_schema import SurveySchema
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Compare two schemas for structure differences")
+
+    parser.add_argument(
+        'SOURCE_SCHEMA',
+        help="The path to the source schema"
+    )
+
+    parser.add_argument(
+        'TARGET_SCHEMA',
+        help="The path to the target schema to compare against"
+    )
+
+    args = parser.parse_args()
+
+    if not os.path.exists(args.SOURCE_SCHEMA):
+        print("{} does not exist".format(args.SOURCE_SCHEMA))
+        exit(2)
+    if not os.path.exists(args.TARGET_SCHEMA):
+        print("{} does not exist".format(args.TARGET_SCHEMA))
+        exit(2)
+
+    source_survey = SurveySchema()
+    source_survey.load(args.SOURCE_SCHEMA)
+    target_survey = SurveySchema()
+    target_survey.load(args.TARGET_SCHEMA)
+
+    compare_schemas(source_survey.schema, target_survey.schema)

--- a/cli/translate_survey.py
+++ b/cli/translate_survey.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 
+from app.utils import compare_schemas
 from app.survey_schema import SurveySchema
 from app.schema_translation import SchemaTranslation
 
@@ -27,13 +28,15 @@ if __name__ == '__main__':
         print("Not a valid output directory")
         exit(2)
 
-    schema = SurveySchema()
-    schema.load(args.SCHEMA_PATH)
+    survey_schema = SurveySchema()
+    survey_schema.load(args.SCHEMA_PATH)
 
     schema_name = os.path.basename(args.SCHEMA_PATH)
 
     translation = SchemaTranslation()
     translation.load(args.TRANSLATION_PATH)
 
-    translated_schema = schema.translate(translation)
+    translated_schema = survey_schema.translate(translation)
     translated_schema.save(os.path.join(args.OUTPUT_DIRECTORY, schema_name))
+
+    compare_schemas(survey_schema.schema, translated_schema.schema)

--- a/tests/test_pointers.py
+++ b/tests/test_pointers.py
@@ -1,6 +1,6 @@
 import unittest
 
-from app.utils import get_parent_pointer, find_pointers_containing, find_pointers_to
+from app.utils import get_parent_pointer, find_pointers_containing, find_pointers_to, list_pointers, compare_schemas
 
 
 class TestPointers(unittest.TestCase):
@@ -107,3 +107,130 @@ class TestPointers(unittest.TestCase):
 
         assert option_parent_pointer == '/questions/0/answers/0/options/0'
         assert answer_parent_pointer == '/questions/0/answers/0'
+
+    def test_list_pointers(self):
+        schema = {
+            'this': 'is',
+            'a': {
+                'test': [{
+                    'item': {}
+                }, {
+                    'item': {}
+                }, {
+                    'item': {}
+                }, {
+                    'item': {}
+                }, {
+                    'item': {}
+                }],
+                'key': [
+                    {'x': {'2': 3}}, 'y', 'z'
+                ]
+            },
+
+        }
+
+        pointers = list(list_pointers(schema))
+
+        assert '/a' in pointers
+        assert '/this' in pointers
+        assert '/a/test' in pointers
+        assert '/a/test/0' in pointers
+        assert '/a/test/1' in pointers
+        assert '/a/test/2' in pointers
+        assert '/a/test/3' in pointers
+        assert '/a/test/4' in pointers
+        assert '/a/test/0/item' in pointers
+        assert '/a/test/1/item' in pointers
+        assert '/a/test/2/item' in pointers
+        assert '/a/test/3/item' in pointers
+        assert '/a/test/4/item' in pointers
+
+        assert '/a/key' in pointers
+        assert '/a/key/0' in pointers
+        assert '/a/key/0/x' in pointers
+        assert '/a/key/0/x/2' in pointers
+        assert '/a/key/1' in pointers
+        assert '/a/key/2' in pointers
+
+    def test_compare_source_schema(self):
+        source_schema = {
+            'this': 'is',
+            'a': {
+                'test': [{
+                    'item': {}
+                }, {
+                    'item': {}
+                }, {
+                    'item': {}
+                }, {
+                    'item': {}
+                }, {
+                    'item': {}
+                }]
+            }
+        }
+
+        target_schema = {
+            'this': 'is',
+            'a': {
+                'test': [{
+                    'item': {}
+                }, {
+                    'item': {}
+                }]
+            }
+        }
+
+        differences = compare_schemas(source_schema, target_schema)
+
+        assert '/a/test/2' in differences
+        assert '/a/test/3' in differences
+        assert '/a/test/4' in differences
+        assert '/a/test/2/item' in differences
+        assert '/a/test/3/item' in differences
+        assert '/a/test/4/item' in differences
+
+        assert len(differences) == 6
+
+    def test_compare_target_schema(self):
+
+        source_schema = {
+            'a': {
+                'test': [{
+                    'item': {}
+                }, {
+                    'item': {}
+                }]
+            }
+        }
+
+        target_schema = {
+            'this': 'is',
+            'a': {
+                'test': [{
+                    'item': {}
+                }, {
+                    'item': {}
+                }, {
+                    'item': {}
+                }],
+                'key': [
+                    {'x': {'2': 3}}, 'y', 'z'
+                ]
+            }
+        }
+
+        differences = compare_schemas(source_schema, target_schema)
+
+        assert '/this' in differences
+        assert '/a/test/2' in differences
+        assert '/a/test/2/item' in differences
+        assert '/a/key' in differences
+        assert '/a/key/0' in differences
+        assert '/a/key/0/x' in differences
+        assert '/a/key/0/x/2' in differences
+        assert '/a/key/1' in differences
+        assert '/a/key/2' in differences
+
+        assert len(differences) == 9


### PR DESCRIPTION
## Motivation

It is currently very difficult to identify structural differences in a schema. It requires a manual process of stepping through two large json structures and checking to see if we can see differences amongst content changes.

This means checking whether a translation process has done anything other than modify text is very time consuming.

## Changes

Add methods that list/compare all pointers within a schema and use them during translation to warn of differences.