### PR TITLE
Add a Census Crowdin Translation Script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ tests/output/
 ._*
 .Spotlight-V100
 .Trashes
+.env

--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,8 @@ name = "pypi"
 pytest = "*"
 babel = "*"
 jsonpointer = "*"
+tqdm = "*"
+requests = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ff0a122d46cc3a5bfdfecf4c28c1cda6b13cdeefdee2d64b7a5eac36595f2246"
+            "sha256": "e8a0fdf9c4df504ac314488a60cb7000a45c0736426e82ec47dff1694793511c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -32,11 +32,39 @@
         },
         "babel": {
             "hashes": [
-                "sha256:6778d85147d5d85345c14a26aada5e478ab04e39b078b0745ee6870c2b5cf669",
-                "sha256:8cba50f48c529ca3fa18cf81fa9403be176d374ac4d60738b839122dfaaa3d23"
+                "sha256:af92e6106cb7c55286b25b38ad7695f8b4efb36a90ba483d7f7a6628c46158ab",
+                "sha256:e86135ae101e31e2c8ec20a4e0c5220f4eed12487d5cf3f78be7e98d3a57fc28"
             ],
             "index": "pypi",
-            "version": "==2.6.0"
+            "version": "==2.7.0"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
+                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
+            ],
+            "version": "==2019.3.9"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+            ],
+            "version": "==2.8"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:027cfc6524613de726789072f95d2e4cc64dd1dee8096d42d13f2ead5bd302f5",
+                "sha256:0d05199e1f0b1a8707a1b9c46476d4a49807fb56cb1b0737db1d37feb42fe31d"
+            ],
+            "version": "==0.15"
         },
         "jsonpointer": {
             "hashes": [
@@ -56,10 +84,10 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:19ecf9ce9db2fce065a7a0586e07cfb4ac8614fe96edf628a264b1c70116cf8f",
-                "sha256:84d306a647cc805219916e62aab89caa97a33a1dd8c342e87a37f91073cd4746"
+                "sha256:0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc",
+                "sha256:b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c"
             ],
-            "version": "==0.9.0"
+            "version": "==0.12.0"
         },
         "py": {
             "hashes": [
@@ -70,11 +98,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:3773f4c235918987d51daf1db66d51c99fac654c81d6f2f709a046ab446d5e5d",
-                "sha256:b7802283b70ca24d7119b32915efa7c409982f59913c1a6c0640aacf118b95f5"
+                "sha256:1a8aa4fa958f8f451ac5441f3ac130d9fc86ea38780dd2715e6d5c5882700b24",
+                "sha256:b8bf138592384bd4e87338cb0f256bf5f615398a649d4bd83915f0e4047a5ca6"
             ],
             "index": "pypi",
-            "version": "==4.4.1"
+            "version": "==4.5.0"
         },
         "pytz": {
             "hashes": [
@@ -83,12 +111,49 @@
             ],
             "version": "==2019.1"
         },
+        "requests": {
+            "hashes": [
+                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
+                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
+            ],
+            "index": "pypi",
+            "version": "==2.22.0"
+        },
         "six": {
             "hashes": [
                 "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
                 "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
             "version": "==1.12.0"
+        },
+        "tqdm": {
+            "hashes": [
+                "sha256:0a860bf2683fdbb4812fe539a6c22ea3f1777843ea985cb8c3807db448a0f7ab",
+                "sha256:e288416eecd4df19d12407d0c913cbf77aa8009d7fddb18f632aded3bdbdda6b"
+            ],
+            "index": "pypi",
+            "version": "==4.32.1"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
+                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
+            ],
+            "version": "==1.25.3"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e",
+                "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
+            ],
+            "version": "==0.1.7"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:8c1019c6aad13642199fbe458275ad6a84907634cc9f0989877ccc4a2840139d",
+                "sha256:ca943a7e809cc12257001ccfb99e3563da9af99d52f261725e96dfe0f9275bc3"
+            ],
+            "version": "==0.5.1"
         }
     },
     "develop": {}

--- a/cli/translate_census.py
+++ b/cli/translate_census.py
@@ -1,0 +1,73 @@
+import requests
+import os
+import sys
+import argparse
+
+from tqdm import tqdm
+
+from app.survey_schema import SurveySchema
+from app.schema_translation import SchemaTranslation
+
+project_id = 'eq-census'
+
+if __name__ == '__main__':
+    try:
+        os.environ["CROWDIN_PROJECT_API_KEY"]
+    except KeyError:
+        print("Required environment variable is not set: CROWDIN_PROJECT_API_KEY")
+        sys.exit(1)
+
+    parser = argparse.ArgumentParser(description="Translate the census survey using crowdin")
+
+    parser.add_argument(
+        'SCHEMA_PATH',
+        help="The path to the source schema to be translated"
+    )
+
+    parser.add_argument(
+        'OUTPUT_DIRECTORY',
+        help="The destination directory for the translation template"
+    )
+
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.OUTPUT_DIRECTORY):
+        print("Not a valid output directory")
+        exit(1)
+
+    file_prefix = 'individual' if 'individual' in args.SCHEMA_PATH else 'household'
+    template_file = f'census_{file_prefix}.pot'
+    output_file = f'census_{file_prefix}-cy.po'
+
+    download_url = 'https://api.crowdin.com/api/project/{project_id}/export-file?key={project_api_key}&file={file}&language={language}'.format(
+        project_id=project_id,
+        project_api_key=os.getenv('CROWDIN_PROJECT_API_KEY'),
+        file=template_file,
+        language='cy'
+    )
+
+    print("Fetching translation file from crowdin")
+
+    response = requests.get(download_url, stream=True)
+
+    if not response:
+        print("Empty response from crowdin")
+        exit(1)
+
+    output_path = os.path.join(args.OUTPUT_DIRECTORY, output_file)
+
+    with open(output_path, 'wb') as handle:
+        for data in tqdm(response.iter_content()):
+            handle.write(data)
+
+    schema = SurveySchema()
+    schema.load(args.SCHEMA_PATH)
+    schema_name = os.path.basename(args.SCHEMA_PATH)
+
+    translation = SchemaTranslation()
+    translation.load(output_path)
+
+    translated_schema = schema.translate(translation)
+    translated_schema.save(os.path.join(args.OUTPUT_DIRECTORY, schema_name))
+
+


### PR DESCRIPTION
## Motivation

To translate a census schema includes a number of steps and requires navigating the crowdin site ui. It would be useful to have a script which could be used to translate as part of an automated process.

## Changes

Add a crowdin translation script, which interacts with the crowdin api to fetch the translation file and use it for translation of a schema.