### PR TITLE
Extract Census Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,32 @@ To translate all surveys in a directory run:
 pipenv run python -m cli.translate_all_surveys <top_level_schema_directory>
 ```
 
+To compare two schemas for differences in structure:
+
+```
+pipenv run python -m cli.compare_schemas <path_to_source_schema> <path_to_target_schema>
+```
+
 To run the tests:
 
 ```
 make test
+```
+
+### Census Commands
+
+To extract the census individual schema from Survey Runner to a pot template
+
+```
+pipenv run python -m cli.extract_census_template <runner_schema_directory> <output_directory>
+pipenv run python -m cli.extract_census_template ../eq-survey-runner/data/en out
+```
+
+To translate the census individual using current translations in crowdin
+
+```
+pipenv run python -m cli.extract_census_template <census_schema> <output_directory>
+pipenv run python -m cli.translate_census ../eq-survey-runner/data/en/census_individual_gb_eng.json out
 ```
 
 ## Naming conventions

--- a/cli/extract_census_template.py
+++ b/cli/extract_census_template.py
@@ -1,0 +1,48 @@
+import argparse
+import os
+import subprocess
+
+from app.survey_schema import SurveySchema
+from app.schema_translation import SchemaTranslation
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Extract a combined translation template from census json schemas")
+
+    parser.add_argument(
+        'RUNNER_SCHEMA_DIRECTORY',
+        help="The path to the runner directory from which data will be extracted"
+    )
+
+    parser.add_argument(
+        'OUTPUT_DIRECTORY',
+        help="The destination directory for the translation template"
+    )
+
+    args = parser.parse_args()
+
+    if not os.path.isdir(os.path.join(args.RUNNER_SCHEMA_DIRECTORY)):
+        print("Runner schema directory does not exist")
+
+    if not os.path.isdir(args.OUTPUT_DIRECTORY):
+        print("Output directory does not exist")
+
+    census_schemas = ['census_individual_gb_eng.json', 'census_individual_gb_wls.json']
+    translation_names = []
+
+    for census_schema in census_schemas:
+        print(f"Extracting from: {census_schema}")
+        survey = SurveySchema()
+        survey.load(os.path.join(args.RUNNER_SCHEMA_DIRECTORY, census_schema))
+
+        catalog = survey.get_catalog()
+
+        schema_name, _ = os.path.splitext(census_schema)
+
+        translation_name = f"{schema_name}.pot"
+        translation = SchemaTranslation(catalog)
+        translation.save(os.path.join(args.OUTPUT_DIRECTORY, translation_name))
+        translation_names.append(translation_name)
+
+    print("Concatenating census extractions together")
+
+    subprocess.run(['msgcat'] + translation_names + ['-o', 'census_individual.pot'], cwd=args.OUTPUT_DIRECTORY)

--- a/cli/template_extractor.py
+++ b/cli/template_extractor.py
@@ -20,7 +20,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if not os.path.isdir(args.OUTPUT_DIRECTORY):
-        print("Not a valid output directory")
+        print("Output directory does not exist")
         exit(2)
 
     schema = SurveySchema()

--- a/cli/translate_all_surveys.py
+++ b/cli/translate_all_surveys.py
@@ -15,7 +15,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if not os.path.isdir(args.SCHEMA_DIRECTORY_PATH):
-        print("Not a valid schema directory")
+        print("Schema directory does not exist")
         exit(2)
 
     available_translations = os.listdir("./translations")

--- a/cli/translate_census.py
+++ b/cli/translate_census.py
@@ -32,7 +32,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if not os.path.isdir(args.OUTPUT_DIRECTORY):
-        print("Not a valid output directory")
+        print("Output directory does not exist")
         exit(1)
 
     file_prefix = 'individual' if 'individual' in args.SCHEMA_PATH else 'household'


### PR DESCRIPTION
## Motivation

Extracting the census individual schema involves extracting from both the different regions versions of the census, concatenating the templates together and uploading to crowdin. As a manual process, it is easy to make a mistake.

## Changes

Create a script which extracts the census_individual.pot in a single step, taking a runner data/en folder as an argument.