### PR TITLE
Add playback and item_title pointer extraction

### DIFF
--- a/eq_translations/survey_schema.py
+++ b/eq_translations/survey_schema.py
@@ -14,6 +14,8 @@ class SurveySchema:
         'hide_guidance',
         'description',
         'legal_basis',
+        'playback',
+        'item_title'
     ]
     context_placeholder_pointers = []
     no_context_placeholder_pointers = []
@@ -113,14 +115,12 @@ class SurveySchema:
     def get_title_pointers(self):
         """
         Titles need to be handled separately as they may require context for translation
-        :return:
         """
         return find_pointers_to(self.schema, 'title')
 
     def get_answer_pointers(self):
         """
         Labels for options/answers need to be handled separately as they require context
-        :return:
         """
         return find_pointers_to(self.schema, 'label')
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='eq_translations',
-      version='0.1',
+      version='0.2',
       description='Translations infrastructure for EQ Questionnaire Runner',
       url='http://github.com/ONSDigital/eq-translations',
       author='ONSDigital',

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,7 @@ setup(name='eq_translations',
       packages=['eq_translations', 'eq_translations.cli'],
       entry_points = {
           'console_scripts': [
-              'template_extractor=eq_translations.cli.template_extractor:main',
-              'translate_all_surveys=eq_translations.cli.translate_all_surveys:main',
+              'extract_template=eq_translations.cli.extract_template:main',
               'translate_census=eq_translations.cli.translate_census:main',
               'translate_schema=eq_translations.cli.translate_schema:main',
               'compare_schemas=eq_translations.cli.compare_schemas:main',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(name='eq_translations',
               'template_extractor=eq_translations.cli.template_extractor:main',
               'translate_all_surveys=eq_translations.cli.translate_all_surveys:main',
               'translate_census=eq_translations.cli.translate_census:main',
-              'translate_survey=eq_translations.cli.translate_schema:main',
+              'translate_schema=eq_translations.cli.translate_schema:main',
               'compare_schemas=eq_translations.cli.compare_schemas:main',
           ]
       },

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(name='eq_translations',
               'template_extractor=eq_translations.cli.template_extractor:main',
               'translate_all_surveys=eq_translations.cli.translate_all_surveys:main',
               'translate_census=eq_translations.cli.translate_census:main',
-              'translate_survey=eq_translations.cli.translate_survey:main',
+              'translate_survey=eq_translations.cli.translate_schema:main',
               'compare_schemas=eq_translations.cli.compare_schemas:main',
           ]
       },

--- a/tests/test_survey_schema.py
+++ b/tests/test_survey_schema.py
@@ -255,6 +255,87 @@ class TestSurveySchema(unittest.TestCase):
         parent_question = schema.get_parent_question('/question/0/answers/0/options/0/label')
         assert parent_question == original_question["title"]
 
+    def test_relationship_playback_extraction(self):
+        relationships_question = {
+            "question": {
+                "id": "relationship-question",
+                "type": "General",
+                "title": "Thinking of {first_person_name}, {second_person_name} is their <em>...</em>",
+                "answers": [
+                    {
+                        "id": "relationship-answer",
+                        "mandatory": True,
+                        "type": "Relationship",
+                        "playback": "{second_person_name} is {first_person_name_possessive} <em>…</em>",
+                        "options": [
+                            {
+                                "label": "Husband or Wife",
+                                "value": "Husband or Wife",
+                                "title": "Thinking of {first_person_name}, {second_person_name} is their <em>husband or wife</em>",
+                                "playback": "{second_person_name} is {first_person_name_possessive} <em>husband or wife</em>"
+                            },
+                            {
+                                "label": "Legally registered civil partner",
+                                "value": "Legally registered civil partner",
+                                "title": "Thinking of {first_person_name}, {second_person_name} is their <em>legally registered civil partner</em>",
+                                "playback": "{second_person_name} is {first_person_name_possessive} <em>legally registered civil partner</em>"
+                            },
+                            {
+                                "label": "Son or daughter",
+                                "value": "Son or daughter",
+                                "title": "Thinking of {first_person_name}, {second_person_name} is their <em>son or daughter</em>",
+                                "playback": "{second_person_name} is {first_person_name_possessive} <em>son or daughter</em>"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+
+        schema = SurveySchema(relationships_question)
+
+        assert "/question/answers/0/playback" in schema.pointers
+
+
+    def test_summary_item_title_with_placeholder_extraction(self):
+        summary_placeholder = {
+            "summary": {
+                "item_title": {
+                    "text": "{person_name}",
+                    "placeholders": [
+                        {
+                            "placeholder": "person_name",
+                            "transforms": [
+                                {
+                                    "arguments": {
+                                        "delimiter": " ",
+                                        "list_to_concatenate": {
+                                            "identifier": ["first-name", "last-name"],
+                                            "source": "answers"
+                                        }
+                                    },
+                                    "transform": "concatenate_list"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+
+        schema = SurveySchema(summary_placeholder)
+        assert "/summary/item_title/text" in schema.pointers
+
+    def test_summary_item_title_without_placeholder_extraction(self):
+        summary_placeholder = {
+            "summary": {
+                "item_title": "A list item"
+            }
+        }
+
+        schema = SurveySchema(summary_placeholder)
+        assert "/summary/item_title" in schema.pointers
+
 
 class TestTranslate(unittest.TestCase):
 


### PR DESCRIPTION
The relationship collector's `playback` key and the summary `item_title` key were not being properly translated.

I don't think either of these keys require context. 

The `item_title` key is currently supported when using placeholders, but validator does allow you to use a plain string, which wouldn't currently be supported.