### PR TITLE
Add list collector keys used on Section Summary

### DIFF
--- a/eq_translations/entrypoints.py
+++ b/eq_translations/entrypoints.py
@@ -3,6 +3,7 @@ import os
 from eq_translations import SurveySchema, SchemaTranslation
 from eq_translations.utils import compare_schemas
 
+
 def handle_extract_template(schema_path, output_directory):
     schema = SurveySchema()
     schema.load(schema_path)
@@ -12,6 +13,7 @@ def handle_extract_template(schema_path, output_directory):
 
     translation = SchemaTranslation(catalog)
     translation.save(os.path.join(output_directory, '{}.pot'.format(schema_name)))
+
 
 def handle_translate_schema(schema_path, translation_path, output_directory):
     survey_schema = SurveySchema()
@@ -26,6 +28,7 @@ def handle_translate_schema(schema_path, translation_path, output_directory):
     translated_schema.save(os.path.join(output_directory, schema_name))
 
     compare_schemas(survey_schema.schema, translated_schema.schema)
+
 
 def handle_compare_schemas(source_schema, target_schema):
     source_survey = SurveySchema()

--- a/eq_translations/survey_schema.py
+++ b/eq_translations/survey_schema.py
@@ -15,7 +15,9 @@ class SurveySchema:
         'description',
         'legal_basis',
         'playback',
-        'item_title'
+        'item_title',
+        'add_link_text',
+        'empty_list_text'
     ]
     context_placeholder_pointers = []
     no_context_placeholder_pointers = []

--- a/tests/test_survey_schema.py
+++ b/tests/test_survey_schema.py
@@ -296,10 +296,29 @@ class TestSurveySchema(unittest.TestCase):
 
         assert "/question/answers/0/playback" in schema.pointers
 
-
-    def test_summary_item_title_with_placeholder_extraction(self):
+    def test_summary_with_placeholder_extraction(self):
         summary_placeholder = {
             "summary": {
+                "title": {
+                    "text": "Answers for {person_name}",
+                    "placeholders": [
+                        {
+                            "placeholder": "person_name",
+                            "transforms": [
+                                {
+                                    "arguments": {
+                                        "delimiter": " ",
+                                        "list_to_concatenate": {
+                                            "identifier": ["first-name", "last-name"],
+                                            "source": "answers"
+                                        }
+                                    },
+                                    "transform": "concatenate_list"
+                                }
+                            ]
+                        }
+                    ]
+                },
                 "item_title": {
                     "text": "{person_name}",
                     "placeholders": [
@@ -319,21 +338,32 @@ class TestSurveySchema(unittest.TestCase):
                             ]
                         }
                     ]
-                }
+                },
+                "empty_list_text": "A list item",
+                "add_link_text": "A list item",
             }
         }
 
         schema = SurveySchema(summary_placeholder)
-        assert "/summary/item_title/text" in schema.pointers
 
-    def test_summary_item_title_without_placeholder_extraction(self):
+        assert "/summary/item_title/text" in schema.pointers
+        assert "/summary/title/text" in schema.pointers
+        assert "/summary/empty_list_text" in schema.pointers
+        assert "/summary/add_link_text" in schema.pointers
+
+    def test_summary_without_placeholder_extraction(self):
         summary_placeholder = {
             "summary": {
-                "item_title": "A list item"
+                "title": "A title for the summary",
+                "item_title": "A list item",
+                "empty_list_text": "A list item",
+                "add_link_text": "A list item",
             }
         }
 
         schema = SurveySchema(summary_placeholder)
+
+        assert "/summary/title" in schema.pointers
         assert "/summary/item_title" in schema.pointers
 
 


### PR DESCRIPTION
### Motivation

New keys have been introduced as part of https://github.com/ONSdigital/eq-survey-runner/pull/2293 and https://github.com/ONSdigital/eq-schema-validator/pull/151 which are visible in section summaries and need to be translated.