### PR TITLE
Fix broken extraction when list element is a string

### DIFF
--- a/eq_translations/survey_schema.py
+++ b/eq_translations/survey_schema.py
@@ -109,9 +109,10 @@ class SurveySchema:
         list_pointers = find_pointers_to(self.schema, 'list')
         for list_pointer in list_pointers:
             schema_element = resolve_pointer(self.schema, list_pointer)
-            pointers.extend(
-                [f'{list_pointer}/{i}' for i, p in enumerate(schema_element)]
-            )
+            if isinstance(schema_element, list):
+                pointers.extend(
+                    [f'{list_pointer}/{i}' for i, p in enumerate(schema_element)]
+                )
         return pointers
 
     def get_title_pointers(self):

--- a/tests/test_survey_schema.py
+++ b/tests/test_survey_schema.py
@@ -130,6 +130,16 @@ class TestSurveySchema(unittest.TestCase):
 
         assert len(pointers) == 4
 
+    def test_no_pointers_when_list_property_isnt_a_list(self):
+        schema = SurveySchema({
+            'list': 'abc',
+        })
+        pointers = schema.get_list_pointers()
+        assert '/list' not in pointers
+        assert '/list/0' not in pointers
+        assert '/list/1' not in pointers
+        assert '/list/2' not in pointers
+
     def test_get_answer_messages(self):
         schema = SurveySchema({
             "sections": [{


### PR DESCRIPTION
The current Census schema contains `when` rules with a `list` property that specifies which list the rule applies to. This element was being incorrectly being extracted as content to be translated, leading to warnings when translating schemas. Valid warnings are at risk of being ignored while these erroneous ones remain. 

### How to test
- Run `pipenv run python -m eq_translations.cli.extract_template ../eq-survey-runner/data/en/census_household_gb_eng.json` and check that single character strings (`h`,`o`,`u`,`s`,`e`,`h`,`o`,`l`,`d`) don't appear in the generated pot file.