### PR TITLE
Fix answers not being translated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ tests/output/
 .Spotlight-V100
 .Trashes
 .env
+.po/

--- a/eq_translations/cli/compare_schemas.py
+++ b/eq_translations/cli/compare_schemas.py
@@ -3,6 +3,7 @@ import os
 
 from eq_translations.entrypoints import handle_compare_schemas
 
+
 def main():
     parser = argparse.ArgumentParser(description='Compare two schemas for structure differences')
 

--- a/eq_translations/cli/extract_template.py
+++ b/eq_translations/cli/extract_template.py
@@ -3,6 +3,7 @@ import os
 
 from eq_translations.entrypoints import handle_extract_template
 
+
 def main():
     parser = argparse.ArgumentParser(description='Extract translation template from json schema')
 

--- a/eq_translations/cli/translate_census.py
+++ b/eq_translations/cli/translate_census.py
@@ -10,6 +10,7 @@ from eq_translations.schema_translation import SchemaTranslation
 
 project_id = 'eq-census'
 
+
 def main():
     try:
         os.environ['CROWDIN_PROJECT_API_KEY']

--- a/eq_translations/cli/translate_schema.py
+++ b/eq_translations/cli/translate_schema.py
@@ -3,6 +3,7 @@ import os
 
 from eq_translations.entrypoints import handle_translate_schema
 
+
 def main():
     parser = argparse.ArgumentParser(description='Translate a schema using a po file')
 
@@ -27,6 +28,7 @@ def main():
         exit(2)
 
     handle_translate_schema(args.SCHEMA_PATH, args.TRANSLATION_PATH, args.OUTPUT_DIRECTORY)
+
 
 if __name__ == '__main__':
     main()

--- a/eq_translations/schema_translation.py
+++ b/eq_translations/schema_translation.py
@@ -19,7 +19,7 @@ class SchemaTranslation:
             pofile.write_po(translation_file, self.catalog)
 
     @staticmethod
-    def messages_equal(message_a, message_b):
+    def dumb_strings_equal(message_a, message_b):
         return dumb_to_smart_quotes(message_a) == dumb_to_smart_quotes(message_b)
 
     @staticmethod
@@ -28,7 +28,7 @@ class SchemaTranslation:
 
     def translate_message(self, message_to_translate, answer_id=None, message_context=None):
         for message in self.catalog:
-            if message.id and SchemaTranslation.messages_equal(message.id, message_to_translate):
+            if message.id and SchemaTranslation.dumb_strings_equal(message.id, message_to_translate):
                 found = True
                 comment_answer_ids = []
 

--- a/eq_translations/schema_translation.py
+++ b/eq_translations/schema_translation.py
@@ -1,6 +1,6 @@
 from babel.messages import pofile
 
-from eq_translations.utils import dumb_to_smart_quotes
+from eq_translations.utils import dumb_to_smart_quotes, are_dumb_strings_equal
 
 
 class SchemaTranslation:
@@ -19,16 +19,12 @@ class SchemaTranslation:
             pofile.write_po(translation_file, self.catalog)
 
     @staticmethod
-    def dumb_strings_equal(message_a, message_b):
-        return dumb_to_smart_quotes(message_a) == dumb_to_smart_quotes(message_b)
-
-    @staticmethod
     def get_comment_answer_ids(comments):
         return [comment.split(':')[1].strip() for comment in comments if 'answer-id' in comment]
 
     def translate_message(self, message_to_translate, answer_id=None, message_context=None):
         for message in self.catalog:
-            if message.id and SchemaTranslation.dumb_strings_equal(message.id, message_to_translate):
+            if message.id and are_dumb_strings_equal(message.id, message_to_translate):
                 found = True
                 comment_answer_ids = []
 

--- a/eq_translations/survey_schema.py
+++ b/eq_translations/survey_schema.py
@@ -192,30 +192,32 @@ class SurveySchema:
 
         for pointer in self.no_context_pointers:
             pointer_contents = resolve_pointer(self.schema, pointer)
-            translation = schema_translation.translate_message(pointer_contents)
-            if translation:
-                translated_schema = set_pointer(translated_schema, pointer, translation)
-            else:
-                missing_translations += 1
-                print(
-                    "Missing translation at {}: '{}'".format(pointer, pointer_contents)
-                )
+            if pointer_contents:
+                translation = schema_translation.translate_message(pointer_contents)
+                if translation:
+                    translated_schema = set_pointer(translated_schema, pointer, translation)
+                else:
+                    missing_translations += 1
+                    print(
+                        "Missing translation at {}: '{}'".format(pointer, pointer_contents)
+                    )
 
         for pointer in self.context_pointers:
             pointer_contents = resolve_pointer(self.schema, pointer)
-            parent_answer_id = self.get_parent_id(pointer)
-            question = self.get_parent_question(pointer)
-            message_context = 'Answer for: {}'.format(question['text'] if is_placeholder(question) else question)
-            translation = schema_translation.translate_message(
-                pointer_contents, parent_answer_id, message_context
-            )
-            if translation:
-                translated_schema = set_pointer(translated_schema, pointer, translation)
-            else:
-                missing_translations += 1
-                print(
-                    f"Missing translation at {pointer}: \'{pointer_contents}\'"
+            if pointer_contents:
+                parent_answer_id = self.get_parent_id(pointer)
+                question = self.get_parent_question(pointer)
+                message_context = 'Answer for: {}'.format(question['text'] if is_placeholder(question) else question)
+                translation = schema_translation.translate_message(
+                    pointer_contents, parent_answer_id, message_context
                 )
+                if translation:
+                    translated_schema = set_pointer(translated_schema, pointer, translation)
+                else:
+                    missing_translations += 1
+                    print(
+                        f"Missing translation at {pointer}: \'{pointer_contents}\'"
+                    )
 
         print(f'\nTotal Messages: {total_translations}')
 

--- a/eq_translations/utils.py
+++ b/eq_translations/utils.py
@@ -107,3 +107,7 @@ def dumb_to_smart_quotes(string):
     string = re.sub(r'‘(MO|TU|WE|TH|FR|SA|SU|EEEE d MMMM YYYY|EEEE dd MMMM|EEEE d MMMM|weeks)’', r"'\1'", string)
 
     return string.strip()
+
+
+def are_dumb_strings_equal(message_a, message_b):
+    return dumb_to_smart_quotes(message_a) == dumb_to_smart_quotes(message_b)

--- a/tests/test_schema_translation.py
+++ b/tests/test_schema_translation.py
@@ -76,3 +76,20 @@ class TestSchemaTranslation(unittest.TestCase):
         translated = translator.translate_message("What is 'this persons' date of birth?")
 
         assert translated == "Beth yw dyddiad geni ‘pobl hyn’?"
+
+    def test_multiple_answer_ids(self):
+
+        catalog = Catalog()
+
+        catalog.add("Answering for this person",
+                    "WELSH - Answering for this person",
+                    auto_comments=["answer-id: feeling-answer", "answer-id: feeling-answer-proxy"],
+                    context="Answer for: Who are you answering for??")
+
+        translator = SchemaTranslation(catalog)
+
+        translation_a = translator.translate_message("Answering for this person", answer_id='feeling-answer')
+        translation_b = translator.translate_message("Answering for this person", answer_id='feeling-answer-proxy')
+
+        assert translation_a == "WELSH - Answering for this person"
+        assert translation_b == "WELSH - Answering for this person"


### PR DESCRIPTION
**Motivation**

Some answers are not being translated when answer translations exist in the translation (.po) file. This is due to some answers where multiple answer ids are listed for a single translation. Or translation currently assumes there is only a single answer id.

**Changes**

Update the answer search to assume context contains a list of answer_ids. Additionally, don't show translation warnings about empty strings.