### PR TITLE
Add instruction key used on CCS

### DIFF
--- a/eq_translations/survey_schema.py
+++ b/eq_translations/survey_schema.py
@@ -17,7 +17,8 @@ class SurveySchema:
         'playback',
         'item_title',
         'add_link_text',
-        'empty_list_text'
+        'empty_list_text',
+        'instruction'
     ]
     context_placeholder_pointers = []
     no_context_placeholder_pointers = []

--- a/eq_translations/survey_schema.py
+++ b/eq_translations/survey_schema.py
@@ -18,7 +18,7 @@ class SurveySchema:
         'item_title',
         'add_link_text',
         'empty_list_text',
-        'instruction'
+        'instruction',
     ]
     context_placeholder_pointers = []
     no_context_placeholder_pointers = []

--- a/tests/test_survey_schema.py
+++ b/tests/test_survey_schema.py
@@ -427,7 +427,8 @@ class TestTranslate(unittest.TestCase):
                                 "title": "Feeling answer",
                                 "description": "This should be answered to see if you are answering on behalf of someone else"
                             }]
-                        }
+                        },
+                        "instruction": "Tell respondent to turn to <strong>Showcard 1</strong>"
                     }]
                 }
             }]
@@ -465,7 +466,8 @@ class TestTranslate(unittest.TestCase):
                                 "title": "Feeling answer",
                                 "description": "This should be answered to see if you are answering on behalf of someone else"
                             }]
-                        }
+                        },
+                        "instruction": "Tell respondent to turn to <strong>Showcard 1</strong>"
                     }]
                 }
             }]

--- a/tests/test_survey_schema.py
+++ b/tests/test_survey_schema.py
@@ -507,7 +507,8 @@ class TestTranslate(unittest.TestCase):
                                 "title": "Feeling answer",
                                 "description": "This should be answered to see if you are answering on behalf of someone else"
                             }]
-                        }
+                        },
+                        "instruction": "Tell respondent to turn to <strong>Showcard 1</strong>"
                     }]
                 }
             }]
@@ -526,6 +527,8 @@ class TestTranslate(unittest.TestCase):
         assert schema_data['sections'][0]['question']['answers'][0]['guidance']['show_guidance'] in actual_items
         assert schema_data['sections'][0]['question']['answers'][0]['guidance']['content'][0]['title'] in actual_items
         assert schema_data['sections'][0]['question']['answers'][0]['guidance']['content'][0]['description'] in actual_items
+        assert schema_data['sections'][0]['question']['answers'][0]['instruction'] in actual_items
+
 
     def test_get_catalog_uses_smart_quotes(self):
         schema_data = {


### PR DESCRIPTION
### Motivation

New key has been introduced as part of https://github.com/ONSdigital/eq-survey-runner/pull/2449 and https://github.com/ONSdigital/eq-schema-validator/pull/168 which are visible in questions and need to be translated.

To run tests:

```
make test
```

To manually test if new key is being translated the following command can be run: 

Extract translatable text from an eQ schema with

```
pipenv run python -m eq_translations.cli.extract_template <schema_file> <output_directory>
```

Check if new "instruction" templates are added to generated .pot file