### PR TITLE
Add regex to replace dumb double quotes

### DIFF
--- a/eq_translations/utils.py
+++ b/eq_translations/utils.py
@@ -112,7 +112,7 @@ def dumb_to_smart_quotes(string):
     # left single quotes.
     string = string.replace("\"", '“')
 
-    return string.strip()
+    return string
 
 
 def remove_quotes(message):

--- a/eq_translations/utils.py
+++ b/eq_translations/utils.py
@@ -99,19 +99,13 @@ def dumb_to_smart_quotes(string):
     # Reverse: Find any SMART quotes that have been (mistakenly) placed around HTML
     # attributes (following =) and replace them with dumb quotes.
     string = re.sub(r'=‘(.*?)’', r"='\1'", string)
-    # Reverse: Find any SMART quotes that have been (mistakenly) placed around Jinja
-    # attributes (following [) and replace them with dumb quotes.
-    string = re.sub(r'\[‘(.*?)’', r"['\1'", string)
-    # Reverse: Find any SMART quotes that have been (mistakenly) placed around date
-    # parameters passed to Jinja filters and replace them with dumb quotes.
-    string = re.sub(r'‘(MO|TU|WE|TH|FR|SA|SU|EEEE d MMMM YYYY|EEEE dd MMMM|EEEE d MMMM|weeks)’', r"'\1'", string)
-    # Find dumb double quotes coming directly after letters or punctuation
-    # and replace them with right smart double quotes
-    string = re.sub(r'([\w.,?!;:\\"\'])\"+(!? )', r'\1” ', string)
-    # Find any remaining dumb double quotes and replace them with
-    # left single quotes.
+
+    # Now repeat the steps above for double quotes
+    string = re.sub(r'([\w.,?!;:\\"\'])\"', r'\1” ', string)
     # pylint: disable=invalid-string-quote
     string = string.replace("\"", '“')
+    string = re.sub(r'=“(.*?)”', r"='\1'", string)
+
 
     return string
 

--- a/eq_translations/utils.py
+++ b/eq_translations/utils.py
@@ -110,6 +110,7 @@ def dumb_to_smart_quotes(string):
     string = re.sub(r'([\w.,?!;:\\"\'])\"+(!? )', r'\1” ', string)
     # Find any remaining dumb double quotes and replace them with
     # left single quotes.
+    # pylint: disable=invalid-string-quote
     string = string.replace("\"", '“')
 
     return string

--- a/eq_translations/utils.py
+++ b/eq_translations/utils.py
@@ -101,11 +101,10 @@ def dumb_to_smart_quotes(string):
     string = re.sub(r'=‘(.*?)’', r"='\1'", string)
 
     # Now repeat the steps above for double quotes
-    string = re.sub(r'([\w.,?!;:\\"\'])\"', r'\1” ', string)
+    string = re.sub(r'([\w.,?!;:\\"\'])\"', r'\1”', string)
     # pylint: disable=invalid-string-quote
     string = string.replace("\"", '“')
     string = re.sub(r'=“(.*?)”', r"='\1'", string)
-
 
     return string
 

--- a/eq_translations/utils.py
+++ b/eq_translations/utils.py
@@ -105,6 +105,12 @@ def dumb_to_smart_quotes(string):
     # Reverse: Find any SMART quotes that have been (mistakenly) placed around date
     # parameters passed to Jinja filters and replace them with dumb quotes.
     string = re.sub(r'‘(MO|TU|WE|TH|FR|SA|SU|EEEE d MMMM YYYY|EEEE dd MMMM|EEEE d MMMM|weeks)’', r"'\1'", string)
+    # Find dumb double quotes coming directly after letters or punctuation
+    # and replace them with right smart double quotes
+    string = re.sub(r'([\w.,?!;:\\"\'])\"+(!? )', r'\1u201D', string)
+    # Find any remaining dumb double quotes and replace them with
+    # left single quotes.
+    string = string.replace("\"", '\u201C')
 
     return string.strip()
 

--- a/eq_translations/utils.py
+++ b/eq_translations/utils.py
@@ -107,7 +107,7 @@ def dumb_to_smart_quotes(string):
     string = re.sub(r'‘(MO|TU|WE|TH|FR|SA|SU|EEEE d MMMM YYYY|EEEE dd MMMM|EEEE d MMMM|weeks)’', r"'\1'", string)
     # Find dumb double quotes coming directly after letters or punctuation
     # and replace them with right smart double quotes
-    string = re.sub(r'([\w.,?!;:\\"\'])\"+(!? )', r'\1”', string)
+    string = re.sub(r'([\w.,?!;:\\"\'])\"+(!? )', r'\1” ', string)
     # Find any remaining dumb double quotes and replace them with
     # left single quotes.
     string = string.replace("\"", '“')

--- a/eq_translations/utils.py
+++ b/eq_translations/utils.py
@@ -107,10 +107,10 @@ def dumb_to_smart_quotes(string):
     string = re.sub(r'‘(MO|TU|WE|TH|FR|SA|SU|EEEE d MMMM YYYY|EEEE dd MMMM|EEEE d MMMM|weeks)’', r"'\1'", string)
     # Find dumb double quotes coming directly after letters or punctuation
     # and replace them with right smart double quotes
-    string = re.sub(r'([\w.,?!;:\\"\'])\"+(!? )', r'\1u201D', string)
+    string = re.sub(r'([\w.,?!;:\\"\'])\"+(!? )', r'\1”', string)
     # Find any remaining dumb double quotes and replace them with
     # left single quotes.
-    string = string.replace("\"", '\u201C')
+    string = string.replace("\"", '“')
 
     return string.strip()
 

--- a/tests/test_dumb_smart_quotes.py
+++ b/tests/test_dumb_smart_quotes.py
@@ -23,9 +23,8 @@ class TestDumbToSmartQuotes(unittest.TestCase):
         self.assertNotEqual(actual, original_text)
         self.assertEqual(actual, expected)
 
-    @unittest.expectedFailure
+
     def test_dumb_to_smart_quotes_english_double(self):
-        # Double quotes not supported yet...
         original_text = '''here is "a sentence with" double dumb "quotes" in the middle'''
         expected = '''here is “a sentence with” double dumb “quotes” in the middle'''
 


### PR DESCRIPTION
### What is the context of this PR?
Adding the dumb quote check to the eq-schema-validator has highlighted an issue with this repo. Dumb double quotes were not being replaced when running 'make translate'. I have added additional regex statements to search and replace the dumb double quotes.

We need to make this change before we add the new method to validator so that our build will not fail(see the validator PR [here](https://github.com/ONSdigital/eq-schema-validator/pull/166)).

### How to review 
Update the eq-translations branch in runner, run 'make build' and check that the translated strings that previously contained double quotes are updated with smart quotes
