### PR TITLE
Add context to child elements of a question

### DIFF
--- a/eq_translations/survey_schema.py
+++ b/eq_translations/survey_schema.py
@@ -50,7 +50,9 @@ class SurveySchema:
             + self.get_title_pointers()
             + self.get_message_pointers()
             + self.get_list_pointers()
+            + self.get_schema_description_pointer()
             + self.no_context_placeholder_pointers
+
         )
 
     @property
@@ -66,6 +68,12 @@ class SurveySchema:
         for key in SurveySchema.no_context_keys:
             key_pointers = find_pointers_to(self.schema, key)
             pointers.extend(key_pointers)
+        return pointers
+
+    def get_schema_description_pointer(self):
+        pointers = []
+        key_pointer = find_pointers_to(self.schema, 'description')
+        pointers.append(key_pointer[0])
         return pointers
 
     def get_placeholder_pointers(self):

--- a/eq_translations/survey_schema.py
+++ b/eq_translations/survey_schema.py
@@ -157,8 +157,6 @@ class SurveySchema:
 
     def get_parent_question(self, pointer):
         question_pointer = self.get_parent_question_pointer(pointer) or ''
-        if question_pointer is None:
-            question_pointer = ''
         return resolve_pointer(self.schema, question_pointer + '/title')
 
     def get_catalog(self):

--- a/eq_translations/survey_schema.py
+++ b/eq_translations/survey_schema.py
@@ -71,7 +71,7 @@ class SurveySchema:
         return pointers
 
     def get_schema_description_pointer(self):
-        return [find_pointers_to(self.schema, 'description')[0]]
+        return [[key_pointer for key_pointer in find_pointers_to(self.schema, 'description')][0]]
 
     def get_placeholder_pointers(self):
         """

--- a/eq_translations/survey_schema.py
+++ b/eq_translations/survey_schema.py
@@ -71,11 +71,7 @@ class SurveySchema:
         return pointers
 
     def get_schema_description_pointer(self):
-        pointers = []
-        key_pointer = find_pointers_to(self.schema, 'description')
-        if key_pointer:
-            pointers.append(key_pointer[0])
-        return pointers
+        return [find_pointers_to(self.schema, 'description')[0]]
 
     def get_placeholder_pointers(self):
         """
@@ -137,7 +133,6 @@ class SurveySchema:
         return find_pointers_to(self.schema, 'label')
 
     def get_description_pointers(self):
-
         return find_pointers_to(self.schema, 'description')[1:]
 
     def get_parent_id(self, pointer):
@@ -158,7 +153,7 @@ class SurveySchema:
             return '/'.join(pointer_parts[:pointer_index + 1])
 
     def get_parent_question(self, pointer):
-        question_pointer = self.get_parent_question_pointer(pointer)
+        question_pointer = self.get_parent_question_pointer(pointer) or ''
         if question_pointer is None:
             question_pointer = ''
         return resolve_pointer(self.schema, question_pointer + '/title')

--- a/eq_translations/survey_schema.py
+++ b/eq_translations/survey_schema.py
@@ -129,7 +129,7 @@ class SurveySchema:
 
     def get_description_pointers(self):
 
-        return find_pointers_to(self.schema, 'description')
+        return find_pointers_to(self.schema, 'description')[1:]
 
     def get_parent_id(self, pointer):
         resolved_data = resolve_pointer(self.schema, pointer)
@@ -150,6 +150,8 @@ class SurveySchema:
 
     def get_parent_question(self, pointer):
         question_pointer = self.get_parent_question_pointer(pointer)
+        if question_pointer is None:
+            question_pointer = ''
         return resolve_pointer(self.schema, question_pointer + '/title')
 
     def get_catalog(self):

--- a/eq_translations/survey_schema.py
+++ b/eq_translations/survey_schema.py
@@ -73,7 +73,8 @@ class SurveySchema:
     def get_schema_description_pointer(self):
         pointers = []
         key_pointer = find_pointers_to(self.schema, 'description')
-        pointers.append(key_pointer[0])
+        if key_pointer:
+            pointers.append(key_pointer[0])
         return pointers
 
     def get_placeholder_pointers(self):

--- a/eq_translations/survey_schema.py
+++ b/eq_translations/survey_schema.py
@@ -12,7 +12,6 @@ class SurveySchema:
     no_context_keys = [
         'show_guidance',
         'hide_guidance',
-        'description',
         'legal_basis',
         'playback',
         'item_title',
@@ -56,7 +55,7 @@ class SurveySchema:
 
     @property
     def context_pointers(self):
-        return self.get_answer_pointers() + self.context_placeholder_pointers
+        return self.get_answer_pointers() + self.get_description_pointers() + self.context_placeholder_pointers
 
     def get_core_pointers(self):
         """
@@ -127,6 +126,10 @@ class SurveySchema:
         Labels for options/answers need to be handled separately as they require context
         """
         return find_pointers_to(self.schema, 'label')
+
+    def get_description_pointers(self):
+
+        return find_pointers_to(self.schema, 'description')
 
     def get_parent_id(self, pointer):
         resolved_data = resolve_pointer(self.schema, pointer)

--- a/eq_translations/survey_schema.py
+++ b/eq_translations/survey_schema.py
@@ -50,7 +50,7 @@ class SurveySchema:
             + self.get_title_pointers()
             + self.get_message_pointers()
             + self.get_list_pointers()
-            + self.get_schema_description_pointer()
+            + self.get_first_description_pointer()
             + self.no_context_placeholder_pointers
 
         )
@@ -70,8 +70,11 @@ class SurveySchema:
             pointers.extend(key_pointers)
         return pointers
 
-    def get_schema_description_pointer(self):
-        return [[key_pointer for key_pointer in find_pointers_to(self.schema, 'description')][0]]
+    def get_first_description_pointer(self):
+        try:
+            return [[key_pointer for key_pointer in find_pointers_to(self.schema, 'description')][0]]
+        except IndexError:
+            return []
 
     def get_placeholder_pointers(self):
         """


### PR DESCRIPTION
This adds context to answer's "description". "Instruction" is only used in CCS and "show/hide guidance" has only two values across single census schema so too many contexts would have to be added to single element . For now, both of these child elements don't get context. Currently, this change requires jsonnet proxy/nonproxy modifications similar to those used with title element. As long as two variants of "description" are created when building schemas, adding context is straightforward. To every translation string it passes "answer_id" of the associated answer and title variant of the question related to the answer.
What does it look like in .pot file:
```
#. answer-id: armed-forces-question
msgctxt "Answer for: Have you <em>previously</em> served in the UK Armed Forces?"
msgid "Current serving members should only select “No”"
msgstr ""

#. answer-id: armed-forces-question
msgctxt ""
"Answer for: Has <em>{person_name}</em> <em>previously</em> served in the "
"UK Armed Forces?"
msgid "Current serving members should only select “No”"
msgstr ""
```
Schema questions are created using rules for title variants.
```
local placeholders = import '../../../lib/placeholders.libsonnet';
local rules = import 'rules.libsonnet';

local question(title, description) = {
  id: 'armed-forces-question',
  title: title,
  guidance: {
    contents: [
      {
        description: description,
      },
    ],
  },
  type: 'General',
  answers: [
    {
      id: 'armed-forces-answer',
      mandatory: false,
      guidance: {
        show_guidance: 'Why your answer is important',
        hide_guidance: 'Why your answer is important',
        contents: [
          {
            description: 'We are measuring the number of people who have served in the UK Armed Forces and have now left. Government and councils need this information to carry out their commitments made under the Armed Forces Covenant. This is a promise by the nation ensuring that those who serve or who have served in the armed forces, and their families, are not disadvantaged.',
          },
        ],
      },
      options: [
        {
          label: 'No',
          value: 'No',
        },
        {
          label: 'Yes, previously served in Regular Armed Forces',
          value: 'Yes, previously served in Regular Armed Forces',
        },
        {
          label: 'Yes, previously served in Reserve Armed Forces',
          value: 'Yes, previously served in Reserve Armed Forces',
        },
      ],
      type: 'Checkbox',
    },
  ],
};
local description = 'Current serving members should only select “No”';

local nonProxyTitle = 'Have you previously served in the UK Armed Forces?';
local proxyTitle = {
  text: 'Has <em>{person_name}</em> previously served in the UK Armed Forces?',
  placeholders: [
    placeholders.personName,
  ],
};

{
  type: 'Question',
  id: 'armed-forces',
  question_variants: [
    {
      question: question(nonProxyTitle, description),
      when: [rules.isNotProxy],
    },
    {
      question: question(proxyTitle, description),
      when: [rules.isProxy],
    },
  ],
}
```