### PR TITLE
Adding the action_text key

### DIFF
--- a/eq_translations/survey_schema.py
+++ b/eq_translations/survey_schema.py
@@ -19,7 +19,7 @@ class SurveySchema:
         'add_link_text',
         'empty_list_text',
         'instruction',
-        'action_text',
+        'cancel_text',
     ]
     context_placeholder_pointers = []
     no_context_placeholder_pointers = []

--- a/eq_translations/survey_schema.py
+++ b/eq_translations/survey_schema.py
@@ -19,6 +19,7 @@ class SurveySchema:
         'add_link_text',
         'empty_list_text',
         'instruction',
+        'action_text',
     ]
     context_placeholder_pointers = []
     no_context_placeholder_pointers = []


### PR DESCRIPTION
This has PR has been opened to add action_text key to eq_translations. This is required to support the PR raised for eq-questionnaire-runner [here](https://github.com/ONSdigital/eq-questionnaire-runner/pull/13).

