### PR TITLE
Remove hard coded census date

### DIFF
--- a/eq_translations/survey_schema.py
+++ b/eq_translations/survey_schema.py
@@ -121,6 +121,7 @@ class SurveySchema:
             schema_element = resolve_pointer(self.schema, list_pointer)
             if isinstance(schema_element, list):
                 for i, p in enumerate(schema_element):
+                    # placeholders are being skipped as they are dealt with elsewhere
                     if not is_placeholder(p):
                         pointers.append(f"{list_pointer}/{i}")
 

--- a/eq_translations/survey_schema.py
+++ b/eq_translations/survey_schema.py
@@ -120,9 +120,10 @@ class SurveySchema:
         for list_pointer in list_pointers:
             schema_element = resolve_pointer(self.schema, list_pointer)
             if isinstance(schema_element, list):
-                pointers.extend(
-                    [f"{list_pointer}/{i}" for i, p in enumerate(schema_element)]
-                )
+                for i, p in enumerate(schema_element):
+                    if not is_placeholder(p):
+                        pointers.append(f"{list_pointer}/{i}")
+
         return pointers
 
     def get_title_pointers(self):

--- a/eq_translations/utils.py
+++ b/eq_translations/utils.py
@@ -134,8 +134,14 @@ def remove_quotes(message):
         "\N{LEFT DOUBLE QUOTATION MARK}",
         "\N{RIGHT DOUBLE QUOTATION MARK}",
     ]
-    for char in quotation_marks:
-        message = message.replace(char, "")
+
+    if isinstance(message, str):
+        for char in quotation_marks:
+            message = message.replace(char, "")
+    else:
+        message = message.get("text")
+        for char in quotation_marks:
+            message = message.replace(char, "")
 
     return message.strip()
 

--- a/tests/test_survey_schema.py
+++ b/tests/test_survey_schema.py
@@ -150,6 +150,59 @@ class TestSurveySchema(unittest.TestCase):
         assert "/list/1" not in pointers
         assert "/list/2" not in pointers
 
+    def test_pointers_when_list_item_is_a_placeholder(self):
+        schema = SurveySchema(
+            {
+                "sections": [
+                    {
+                        "content": [
+                            {
+                                "title": "Include:",
+                                "list": [
+                                    "all employees in Great Britain (England, Scotland and Wales), both full and "
+                                    "part-time, who received pay in the relevant period "
+                                ],
+                            },
+                            {
+                                "title": "Exclude:",
+                                "list": [
+                                    {
+                                        "placeholders": [
+                                            {
+                                                "placeholder": "date",
+                                                "transforms": [
+                                                    {
+                                                        "arguments": {
+                                                            "date_format": "d MMMM yyyy",
+                                                            "date_to_format": {
+                                                                "value": "2019-10-09"
+                                                            },
+                                                        },
+                                                        "transform": "format_date",
+                                                    }
+                                                ],
+                                            }
+                                        ],
+                                        "text": "trainees on government schemes on {date}",
+                                    },
+                                    "employees working abroad unless paid directly from this business’s GB payroll",
+                                    "employees in Northern Ireland",
+                                ],
+                            },
+                        ]
+                    }
+                ]
+            }
+        )
+        pointers = schema.get_list_pointers()
+
+        assert "/sections/0/content/0/list/0" in pointers
+        assert "/sections/0/content/1/list/0" not in pointers
+        assert "/sections/0/content/1/list/1" in pointers
+        assert "/sections/0/content/1/list/2" in pointers
+
+        assert len(pointers) == 3
+
     def test_get_answer_messages(self):
         schema = SurveySchema(
             {


### PR DESCRIPTION
### What is the context of this PR?
This adds support for translations and tests of multiple items on a list. Previously, placeholders were not used in lists of contents(despite existing rules in validator) and methods were expecting only strings to be passed during translation process and checks.
The change is described on this trello [card](https://trello.com/c/d8k4s5QA) and requires this
[schema PR](https://github.com/ONSdigital/eq-questionnaire-schemas/pull/19) to be merged.