### PR TITLE
Fix pointer contents for list items with placeholder

### DIFF
--- a/eq_translations/survey_schema.py
+++ b/eq_translations/survey_schema.py
@@ -169,8 +169,10 @@ class SurveySchema:
 
         for pointer in self.no_context_pointers:
             pointer_contents = resolve_pointer(self.schema, pointer)
-            if pointer_contents:
+            if isinstance(pointer_contents, str):
                 catalog.add(dumb_to_smart_quotes(pointer_contents))
+            else:
+                catalog.add(dumb_to_smart_quotes(pointer_contents.get("text")))
 
         for pointer in self.context_pointers:
             pointer_contents = resolve_pointer(self.schema, pointer)


### PR DESCRIPTION
### What is the context of this PR?
This fixes test-translation-template extraction of schema contents based on a pointers. After adding placeholder to contents lists in eq-questionnaire-schemas repo, placeholder and strings were being passed to _dumb_to_smart_qoutes_ function  as a dictionary. That caused it to fail during builds of schema PR.

### How to review 
Use **make test-translation-templates** in schemas repo using "remove-hard-coded-census-date" branch.
