### PR TITLE
Add line break functionality to instruction and description

### DIFF
--- a/eq_translations/__init__.py
+++ b/eq_translations/__init__.py
@@ -3,4 +3,4 @@ from .survey_schema import SurveySchema
 
 __all__ = ("__version__", "SurveySchema", "SchemaTranslation")
 
-__version__ = "3.1.0"
+__version__ = "4.0.0"

--- a/eq_translations/extractable_strings.py
+++ b/eq_translations/extractable_strings.py
@@ -39,7 +39,7 @@ EXTRACTABLE_STRINGS = [
         "description": "List collector add block cancel link",
     },
     {"json_path": "$..content.title", "description": "Content page main heading"},
-    {"json_path": "$..content.instruction", "description": "Content instruction"},
+    {"json_path": "$..content.instruction[*]", "description": "Content instruction"},
     {
         "json_path": "$..content.contents[*].title",
         "description": "Content page heading",
@@ -63,7 +63,7 @@ EXTRACTABLE_STRINGS = [
         "context": "Question",
     },
     {
-        "json_path": "$..question.instruction",
+        "json_path": "$..question.instruction[*]",
         "description": "Question instruction",
         "context": "Question",
     },

--- a/eq_translations/extractable_strings.py
+++ b/eq_translations/extractable_strings.py
@@ -58,7 +58,7 @@ EXTRACTABLE_STRINGS = [
     },
     {"json_path": "$..question.title", "description": "Question text"},
     {
-        "json_path": "$..question.description",
+        "json_path": "$..question.description[*]",
         "description": "Question description",
         "context": "Question",
     },

--- a/tests/schemas/cy/test_language.json
+++ b/tests/schemas/cy/test_language.json
@@ -29,6 +29,9 @@
                             "type": "Question",
                             "id": "name-block",
                             "question": {
+                                "instruction": [
+                                    "Rhowch enw person"
+                                ],
                                 "description": [
                                     "Enw llawn y person"
                                 ],
@@ -59,7 +62,7 @@
                             "question": {
                                 "description": [
                                     {
-                                        "text":"dyddiad geni {person_name_possessive}",
+                                        "text": "dyddiad geni {person_name_possessive}",
                                         "placeholders": [
                                             {
                                                 "placeholder": "person_name_possessive",
@@ -68,7 +71,10 @@
                                                         "arguments": {
                                                             "delimiter": " ",
                                                             "list_to_concatenate": {
-                                                                "identifier": ["first-name", "last-name"],
+                                                                "identifier": [
+                                                                    "first-name",
+                                                                    "last-name"
+                                                                ],
                                                                 "source": "answers"
                                                             }
                                                         },

--- a/tests/schemas/cy/test_language.json
+++ b/tests/schemas/cy/test_language.json
@@ -29,7 +29,9 @@
                             "type": "Question",
                             "id": "name-block",
                             "question": {
-                                "description": "",
+                                "description": [
+                                    "Enw llawn y person"
+                                ],
                                 "id": "name-question",
                                 "title": "Rhowch enw",
                                 "type": "General",
@@ -55,7 +57,9 @@
                             "type": "Question",
                             "id": "dob-block",
                             "question": {
-                                "description": "",
+                                "description": [
+                                    "dyddiad geni {person_name_possessive}"
+                                ],
                                 "id": "dob-question",
                                 "title": {
                                     "text": "Beth yw dyddiad geni {person_name_possessive}?",
@@ -118,7 +122,9 @@
                                         }
                                     }
                                 ],
-                                "description": "",
+                                "description": [
+                                    "Cyfanswm y bobl ar yr aelwyd"
+                                ],
                                 "warning": "Mae hwn yn gwestiwn pwysig iawn",
                                 "id": "number-of-people-question",
                                 "title": "Faint o bobl sy\u2019n byw ar eich cartref?",

--- a/tests/schemas/cy/test_language.json
+++ b/tests/schemas/cy/test_language.json
@@ -58,7 +58,34 @@
                             "id": "dob-block",
                             "question": {
                                 "description": [
-                                    "dyddiad geni {person_name_possessive}"
+                                    {
+                                        "text":"dyddiad geni {person_name_possessive}",
+                                        "placeholders": [
+                                            {
+                                                "placeholder": "person_name_possessive",
+                                                "transforms": [
+                                                    {
+                                                        "arguments": {
+                                                            "delimiter": " ",
+                                                            "list_to_concatenate": {
+                                                                "identifier": ["first-name", "last-name"],
+                                                                "source": "answers"
+                                                            }
+                                                        },
+                                                        "transform": "concatenate_list"
+                                                    },
+                                                    {
+                                                        "arguments": {
+                                                            "string_to_format": {
+                                                                "source": "previous_transform"
+                                                            }
+                                                        },
+                                                        "transform": "format_possessive"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
                                 ],
                                 "id": "dob-question",
                                 "title": {

--- a/tests/schemas/en/test_language.json
+++ b/tests/schemas/en/test_language.json
@@ -58,7 +58,34 @@
                             "id": "dob-block",
                             "question": {
                                 "description": [
-                                    "{person_name_possessive} date of birth"
+                                    {
+                                        "text": "{person_name_possessive} date of birth",
+                                        "placeholders": [
+                                            {
+                                                "placeholder": "person_name_possessive",
+                                                "transforms": [
+                                                    {
+                                                        "arguments": {
+                                                            "delimiter": " ",
+                                                            "list_to_concatenate": {
+                                                                "identifier": ["first-name", "last-name"],
+                                                                "source": "answers"
+                                                            }
+                                                        },
+                                                        "transform": "concatenate_list"
+                                                    },
+                                                    {
+                                                        "arguments": {
+                                                            "string_to_format": {
+                                                                "source": "previous_transform"
+                                                            }
+                                                        },
+                                                        "transform": "format_possessive"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
                                 ],
                                 "id": "dob-question",
                                 "title": {

--- a/tests/schemas/en/test_language.json
+++ b/tests/schemas/en/test_language.json
@@ -29,6 +29,9 @@
                             "type": "Question",
                             "id": "name-block",
                             "question": {
+                                "instruction": [
+                                    "Enter the name of a person"
+                                ],
                                 "description": [
                                     "The full name of the person"
                                 ],

--- a/tests/schemas/en/test_language.json
+++ b/tests/schemas/en/test_language.json
@@ -29,7 +29,9 @@
                             "type": "Question",
                             "id": "name-block",
                             "question": {
-                                "description": "",
+                                "description": [
+                                    "The full name of the person"
+                                ],
                                 "id": "name-question",
                                 "title": "Please enter a name",
                                 "type": "General",
@@ -55,7 +57,9 @@
                             "type": "Question",
                             "id": "dob-block",
                             "question": {
-                                "description": "",
+                                "description": [
+                                    "{person_name_possessive} date of birth"
+                                ],
                                 "id": "dob-question",
                                 "title": {
                                     "text": "What is {person_name_possessive} date of birth?",
@@ -115,7 +119,9 @@
                                         }
                                     }
                                 ],
-                                "description": "",
+                                "description": [
+                                    "The total number of people in the household"
+                                ],
                                 "warning": "This is a very important question",
                                 "id": "number-of-people-question",
                                 "title": "How many people live at your household?",

--- a/tests/schemas/en/test_translation.json
+++ b/tests/schemas/en/test_translation.json
@@ -357,7 +357,9 @@
                                     }
                                 ],
                                 "title": "How many people live here?",
-                                "description": "",
+                                "description": [
+                                    "The total number of people in the property"
+                                ],
                                 "id": "number-of-people-question",
                                 "type": "General"
                             }
@@ -447,7 +449,9 @@
                                     }
                                 ],
                                 "title": "How many visitors have lived here?",
-                                "description": "",
+                                "description": [
+                                    "The total number of visitors who were in the property"
+                                ],
                                 "id": "number-of-visitors-question",
                                 "type": "General"
                             }

--- a/tests/schemas/test_language-cy.po
+++ b/tests/schemas/test_language-cy.po
@@ -57,6 +57,11 @@ msgctxt "How many people live at your household?"
 msgid "The total number of people in the household"
 msgstr "Cyfanswm y bobl ar yr aelwyd"
 
+#. Question instruction
+msgctxt "Please enter a name"
+msgid "Enter the name of a person"
+msgstr "Rhowch enw person"
+
 #. Question warning
 msgctxt "How many people live at your household?"
 msgid "This is a very important question"

--- a/tests/schemas/test_language-cy.po
+++ b/tests/schemas/test_language-cy.po
@@ -42,6 +42,21 @@ msgstr[3] "Mae {number_of_people} pherson yn byw yma, ydy hyn yn gywir? (few)"
 msgstr[4] "Mae {number_of_people} pherson yn byw yma, ydy hyn yn gywir? (many)"
 msgstr[5] "Mae {number_of_people} pherson yn byw yma, ydy hyn yn gywir? (other)"
 
+#. Question description
+msgctxt "Please enter a name"
+msgid "The full name of the person"
+msgstr "Enw llawn y person"
+
+#. Question description
+msgctxt "What is {person_name_possessive} date of birth?"
+msgid "{person_name_possessive} date of birth"
+msgstr "dyddiad geni {person_name_possessive}"
+
+#. Question description
+msgctxt "How many people live at your household?"
+msgid "The total number of people in the household"
+msgstr "Cyfanswm y bobl ar yr aelwyd"
+
 #. Question warning
 msgctxt "How many people live at your household?"
 msgid "This is a very important question"

--- a/tests/schemas/test_language.pot
+++ b/tests/schemas/test_language.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-07-13 11:06+0100\n"
+"POT-Creation-Date: 2020-07-21 10:56+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -52,6 +52,11 @@ msgstr ""
 #. Question description
 msgctxt "How many people live at your household?"
 msgid "The total number of people in the household"
+msgstr ""
+
+#. Question instruction
+msgctxt "Please enter a name"
+msgid "Enter the name of a person"
 msgstr ""
 
 #. Question warning

--- a/tests/schemas/test_language.pot
+++ b/tests/schemas/test_language.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-06-01 11:33+0100\n"
+"POT-Creation-Date: 2020-07-13 11:06+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -38,6 +38,21 @@ msgid "{number_of_people} person lives here, is this correct?"
 msgid_plural "{number_of_people} people live here, is this correct?"
 msgstr[0] ""
 msgstr[1] ""
+
+#. Question description
+msgctxt "Please enter a name"
+msgid "The full name of the person"
+msgstr ""
+
+#. Question description
+msgctxt "What is {person_name_possessive} date of birth?"
+msgid "{person_name_possessive} date of birth"
+msgstr ""
+
+#. Question description
+msgctxt "How many people live at your household?"
+msgid "The total number of people in the household"
+msgstr ""
 
 #. Question warning
 msgctxt "How many people live at your household?"


### PR DESCRIPTION
### What is the context of this PR?

Updating the extractable string for question descriptions to be comprised of a list of strings. Required for https://trello.com/c/On5OBCNm/3939-add-line-break-functionality-in-question-description-m

### How to review 
Confirm that the translate-able string has be updated as expected and schemas and translation templates match.
