### PR TITLE
Add schema translations test for null answer label

### DIFF
--- a/tests/test_survey_schema_translation.py
+++ b/tests/test_survey_schema_translation.py
@@ -527,7 +527,7 @@ def test_checkbox_null_label():
     expected = {
         "question": {
             "answers": [
-                {"label": None, "options": [{"label": "Rygbi", "value": "Rugby"},],}
+                {"label": None, "options": [{"label": "Rygbi", "value": "Rugby"}]}
             ],
         },
         "language": "cy",

--- a/tests/test_survey_schema_translation.py
+++ b/tests/test_survey_schema_translation.py
@@ -518,7 +518,7 @@ def test_checkbox_null_label():
         {
             "question": {
                 "answers": [
-                    {"label": None, "options": [{"label": "Rugby", "value": "Rugby"},],}
+                    {"label": None, "options": [{"label": "Rugby", "value": "Rugby"}]}
                 ],
             }
         }

--- a/tests/test_survey_schema_translation.py
+++ b/tests/test_survey_schema_translation.py
@@ -504,3 +504,49 @@ def test_locale_on_load_ulster_scots():
     translation.load("tests/schemas/test_language-eo.po")
 
     assert translation.language == "eo"
+
+
+def test_checkbox_null_label():
+
+    schema_translation = SchemaTranslation()
+    catalog = Catalog(locale=Locale("cy"))
+    catalog.add(
+        "Rugby",
+        "Rygbi",
+    )
+    schema_translation.catalog = catalog
+    schema = SurveySchema(
+        {
+            "question": {
+                "answers": [
+                    {
+                        "label": None,
+                        "options": [
+                            {
+                                "label": "Rugby",
+                                "value": "Rugby"
+                            },
+                        ],
+                    }
+                ],
+            }
+        }
+    )
+    translated = schema.translate(schema_translation)
+    expected = {
+        "question": {
+            "answers": [
+                {
+                    "label": None,
+                    "options": [
+                        {
+                            "label": "Rygbi",
+                            "value": "Rugby"
+                        },
+                    ],
+                }
+            ],
+        },
+        "language": "cy",
+    }
+    assert expected == translated.schema

--- a/tests/test_survey_schema_translation.py
+++ b/tests/test_survey_schema_translation.py
@@ -329,7 +329,10 @@ def test_placeholder_translation(schema_with_placeholders):
                                 "arguments": {
                                     "delimiter": " ",
                                     "list_to_concatenate": {
-                                        "identifier": ["first-name", "last-name",],
+                                        "identifier": [
+                                            "first-name",
+                                            "last-name",
+                                        ],
                                         "source": "answers",
                                     },
                                 },
@@ -392,11 +395,15 @@ def test_variant_translation(schema_with_question_variants):
     catalog = Catalog()
 
     catalog.add(
-        "First name", "WELSH - First name", context="What is your name?",
+        "First name",
+        "WELSH - First name",
+        context="What is your name?",
     )
 
     catalog.add(
-        "First name", "WELSH - First name - Proxy", context="What is their name?",
+        "First name",
+        "WELSH - First name - Proxy",
+        context="What is their name?",
     )
 
     schema_translation.catalog = catalog
@@ -522,10 +529,7 @@ def test_checkbox_null_label():
                     {
                         "label": None,
                         "options": [
-                            {
-                                "label": "Rugby",
-                                "value": "Rugby"
-                            },
+                            {"label": "Rugby", "value": "Rugby"},
                         ],
                     }
                 ],
@@ -539,10 +543,7 @@ def test_checkbox_null_label():
                 {
                     "label": None,
                     "options": [
-                        {
-                            "label": "Rygbi",
-                            "value": "Rugby"
-                        },
+                        {"label": "Rygbi", "value": "Rugby"},
                     ],
                 }
             ],

--- a/tests/test_survey_schema_translation.py
+++ b/tests/test_survey_schema_translation.py
@@ -329,10 +329,7 @@ def test_placeholder_translation(schema_with_placeholders):
                                 "arguments": {
                                     "delimiter": " ",
                                     "list_to_concatenate": {
-                                        "identifier": [
-                                            "first-name",
-                                            "last-name",
-                                        ],
+                                        "identifier": ["first-name", "last-name",],
                                         "source": "answers",
                                     },
                                 },
@@ -395,15 +392,11 @@ def test_variant_translation(schema_with_question_variants):
     catalog = Catalog()
 
     catalog.add(
-        "First name",
-        "WELSH - First name",
-        context="What is your name?",
+        "First name", "WELSH - First name", context="What is your name?",
     )
 
     catalog.add(
-        "First name",
-        "WELSH - First name - Proxy",
-        context="What is their name?",
+        "First name", "WELSH - First name - Proxy", context="What is their name?",
     )
 
     schema_translation.catalog = catalog
@@ -518,20 +511,14 @@ def test_checkbox_null_label():
     schema_translation = SchemaTranslation()
     catalog = Catalog(locale=Locale("cy"))
     catalog.add(
-        "Rugby",
-        "Rygbi",
+        "Rugby", "Rygbi",
     )
     schema_translation.catalog = catalog
     schema = SurveySchema(
         {
             "question": {
                 "answers": [
-                    {
-                        "label": None,
-                        "options": [
-                            {"label": "Rugby", "value": "Rugby"},
-                        ],
-                    }
+                    {"label": None, "options": [{"label": "Rugby", "value": "Rugby"},],}
                 ],
             }
         }
@@ -540,12 +527,7 @@ def test_checkbox_null_label():
     expected = {
         "question": {
             "answers": [
-                {
-                    "label": None,
-                    "options": [
-                        {"label": "Rygbi", "value": "Rugby"},
-                    ],
-                }
+                {"label": None, "options": [{"label": "Rygbi", "value": "Rugby"},],}
             ],
         },
         "language": "cy",


### PR DESCRIPTION
### What is the context of this PR?
This adds test for schema .pot file translations and extraction of translatable items when there is empty("null") label present in answers.

### How to review 
Run `make test`, run extract and translate of checkbox schema with empty label.