### PR TITLE
Support translation of placeholder text in dropdown answers

### DIFF
--- a/eq_translations/__init__.py
+++ b/eq_translations/__init__.py
@@ -3,4 +3,4 @@ from .survey_schema import SurveySchema
 
 __all__ = ("__version__", "SurveySchema", "SchemaTranslation")
 
-__version__ = "4.4.0"
+__version__ = "4.5.0"

--- a/eq_translations/extractable_strings.py
+++ b/eq_translations/extractable_strings.py
@@ -145,7 +145,7 @@ EXTRACTABLE_STRINGS = [
     },
     {
         "json_path": "$..answers[*].placeholder",
-        "description": "Placeholder text used for select field",
+        "description": "Dropdown field placeholder text",
         "context": "Question",
     },
     {

--- a/eq_translations/extractable_strings.py
+++ b/eq_translations/extractable_strings.py
@@ -144,6 +144,11 @@ EXTRACTABLE_STRINGS = [
         "context": "Question",
     },
     {
+        "json_path": "$..answers[*].placeholder",
+        "description": "Placeholder text used for select field",
+        "context": "Question",
+    },
+    {
         "json_path": "$..answers[*].description",
         "description": "Answer description",
         "context": "Question",

--- a/tests/schemas/cy/test_language.json
+++ b/tests/schemas/cy/test_language.json
@@ -268,6 +268,39 @@
                                     }
                                 ]
                             }
+                        },
+                        {
+                            "type": "Question",
+                            "id": "dropdown-mandatory",
+                            "question": {
+                                "type": "General",
+                                "id": "dropdown-mandatory-question",
+                                "title": "Pa d\u00eem p\u00eal-droed ydych chi\u2019n ei gefnogi?",
+                                "answers": [
+                                    {
+                                        "type": "Dropdown",
+                                        "id": "dropdown-mandatory-answer",
+                                        "mandatory": true,
+                                        "label": "T\u00eem p\u00eal-droed",
+                                        "placeholder": "Dewis opsiwn",
+                                        "description": "Eich hoff d\u00eem o\u2019r Uwch Gynghrair.",
+                                        "options": [
+                                            {
+                                                "label": "Lerpwl",
+                                                "value": "Liverpool"
+                                            },
+                                            {
+                                                "label": "Chelsea",
+                                                "value": "Chelsea"
+                                            },
+                                            {
+                                                "label": "Mae rygbi\u2019n well!",
+                                                "value": "Rugby is better!"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
                         }
                     ]
                 }

--- a/tests/schemas/en/test_language.json
+++ b/tests/schemas/en/test_language.json
@@ -256,6 +256,39 @@
                                     }
                                 ]
                             }
+                        },
+                        {
+                            "type": "Question",
+                            "id": "dropdown-mandatory",
+                            "question": {
+                                "type": "General",
+                                "id": "dropdown-mandatory-question",
+                                "title": "Which football team do you support?",
+                                "answers": [
+                                    {
+                                        "type": "Dropdown",
+                                        "id": "dropdown-mandatory-answer",
+                                        "mandatory": true,
+                                        "label": "Football team",
+                                        "placeholder": "Select an option",
+                                        "description": "Your favourite team from the Premier League.",
+                                        "options": [
+                                            {
+                                                "label": "Liverpool",
+                                                "value": "Liverpool"
+                                            },
+                                            {
+                                                "label": "Chelsea",
+                                                "value": "Chelsea"
+                                            },
+                                            {
+                                                "label": "Rugby is better!",
+                                                "value": "Rugby is better!"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
                         }
                     ]
                 }

--- a/tests/schemas/ga/test_language.json
+++ b/tests/schemas/ga/test_language.json
@@ -48,7 +48,7 @@
                                             "title": "D\u00e0ta pearsanta",
                                             "contents": [
                                                 {
-                                                    "description": "Tha d\u00e0ta pearsanta a \u2019ciallachadh fiosrachadh sam bith co-cheangailte ri neach a chaidh ainmeachadh noneach fa-leth aithneachad"
+                                                    "description": "Tha d\u00e0ta pearsanta a \u2019ciallachadh fiosrachadh sam bith co-cheangailte ri neach a chaidh ainmeachadh noneach fa-leth aithneachadh"
                                                 }
                                             ]
                                         }
@@ -93,7 +93,7 @@
                             "question": {
                                 "description": [
                                     {
-                                        "text": "d\u00e1ta breithe {person_name_possessive} \u201c",
+                                        "text": "d\u00e1ta breithe {person_name_possessive}",
                                         "placeholders": [
                                             {
                                                 "placeholder": "person_name_possessive",
@@ -261,6 +261,39 @@
                                             {
                                                 "label": "N\u00edl",
                                                 "value": "No"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "Question",
+                            "id": "dropdown-mandatory",
+                            "question": {
+                                "type": "General",
+                                "id": "dropdown-mandatory-question",
+                                "title": "C\u00e9n fhoireann peile a dtaca\u00edonn t\u00fa leis?",
+                                "answers": [
+                                    {
+                                        "type": "Dropdown",
+                                        "id": "dropdown-mandatory-answer",
+                                        "mandatory": true,
+                                        "label": "Foireann peile",
+                                        "placeholder": "Roghnaigh rogha",
+                                        "description": "An fhoireann is fearr leat \u00f3n Premier League.",
+                                        "options": [
+                                            {
+                                                "label": "Learpholl",
+                                                "value": "Liverpool"
+                                            },
+                                            {
+                                                "label": "Chelsea",
+                                                "value": "Chelsea"
+                                            },
+                                            {
+                                                "label": "Is fearr rugba\u00ed!",
+                                                "value": "Rugby is better!"
                                             }
                                         ]
                                     }

--- a/tests/schemas/test_language-cy.po
+++ b/tests/schemas/test_language-cy.po
@@ -93,6 +93,10 @@ msgstr[3] "Mae {number_of_people} pherson yn byw yma, ydy hyn yn gywir? (few)"
 msgstr[4] "Mae {number_of_people} pherson yn byw yma, ydy hyn yn gywir? (many)"
 msgstr[5] "Mae {number_of_people} pherson yn byw yma, ydy hyn yn gywir? (other)"
 
+#. Question text
+msgid "Which football team do you support?"
+msgstr "Pa dîm pêl-droed ydych chi'n ei gefnogi?"
+
 #. Question description
 msgctxt "Please enter a name"
 msgid "The full name of the person"
@@ -138,11 +142,27 @@ msgctxt "How many people live at your household?"
 msgid "Number of household residents"
 msgstr "Nifer o breswylwyr yn y cartref"
 
+#. Answer
+msgctxt "Which football team do you support?"
+msgid "Football team"
+msgstr "Tîm pêl-droed"
+
+#. Placeholder text used for select field
+msgctxt "Which football team do you support?"
+msgid "Select an option"
+msgstr "Dewis opsiwn"
+
 #. Answer description
 #. For answer: Date of Birth
 msgctxt "What is {person_name_possessive} date of birth?"
 msgid "Enter your date of birth"
 msgstr "Rhowch eich dyddiad geni"
+
+#. Answer description
+#. For answer: Football team
+msgctxt "Which football team do you support?"
+msgid "Your favourite team from the Premier League."
+msgstr "Eich hoff dîm o'r Uwch Gynghrair."
 
 #. Answer option
 msgctxt "{number_of_people} people live here, is this correct?"
@@ -159,3 +179,18 @@ msgstr[5] "Ydy, mae {number_of_people} pherson yn byw yma (other)"
 msgctxt "{number_of_people} people live here, is this correct?"
 msgid "No"
 msgstr "Na"
+
+#. Answer option
+msgctxt "Which football team do you support?"
+msgid "Liverpool"
+msgstr "Lerpwl"
+
+#. Answer option
+msgctxt "Which football team do you support?"
+msgid "Chelsea"
+msgstr "Chelsea"
+
+#. Answer option
+msgctxt "Which football team do you support?"
+msgid "Rugby is better!"
+msgstr "Mae rygbi'n well!"

--- a/tests/schemas/test_language-cy.po
+++ b/tests/schemas/test_language-cy.po
@@ -147,7 +147,7 @@ msgctxt "Which football team do you support?"
 msgid "Football team"
 msgstr "Tîm pêl-droed"
 
-#. Placeholder text used for select field
+#. Dropdown field placeholder text
 msgctxt "Which football team do you support?"
 msgid "Select an option"
 msgstr "Dewis opsiwn"

--- a/tests/schemas/test_language-ga.po
+++ b/tests/schemas/test_language-ga.po
@@ -148,7 +148,7 @@ msgctxt "Which football team do you support?"
 msgid "Football team"
 msgstr "Foireann peile"
 
-#. Placeholder text used for select field
+#. Dropdown field placeholder text
 msgctxt "Which football team do you support?"
 msgid "Select an option"
 msgstr "Roghnaigh rogha"

--- a/tests/schemas/test_language-ga.po
+++ b/tests/schemas/test_language-ga.po
@@ -70,7 +70,7 @@ msgid ""
 "identifiable individual"
 msgstr ""
 "Tha dàta pearsanta a ’ciallachadh fiosrachadh sam bith co-cheangailte ri neach a chaidh ainmeachadh no"
-"neach fa-leth aithneachadh
+"neach fa-leth aithneachadh"
 
 #. Question text
 msgid "Please enter a name"
@@ -94,6 +94,10 @@ msgstr[3] "Gaelic (few)"
 msgstr[4] "Gaelic (many)"
 msgstr[5] "Gaelic (other)"
 
+#. Question text
+msgid "Which football team do you support?"
+msgstr "Cén fhoireann peile a dtacaíonn tú leis?"
+
 #. Question description
 msgctxt "Please enter a name"
 msgid "The full name of the person"
@@ -102,7 +106,7 @@ msgstr "Ainm iomlán an duine"
 #. Question description
 msgctxt "What is {person_name_possessive} date of birth?"
 msgid "{person_name_possessive} date of birth"
-msgstr "dáta breithe {person_name_possessive} ""
+msgstr "dáta breithe {person_name_possessive}"
 
 #. Question description
 msgctxt "How many people live at your household?"
@@ -139,11 +143,27 @@ msgctxt "How many people live at your household?"
 msgid "Number of household residents"
 msgstr "Líon cónaitheoirí tí"
 
+#. Answer
+msgctxt "Which football team do you support?"
+msgid "Football team"
+msgstr "Foireann peile"
+
+#. Placeholder text used for select field
+msgctxt "Which football team do you support?"
+msgid "Select an option"
+msgstr "Roghnaigh rogha"
+
 #. Answer description
 #. For answer: Date of Birth
 msgctxt "What is {person_name_possessive} date of birth?"
 msgid "Enter your date of birth"
 msgstr "Cuir isteach do dháta breithe"
+
+#. Answer description
+#. For answer: Football team
+msgctxt "Which football team do you support?"
+msgid "Your favourite team from the Premier League."
+msgstr "An fhoireann is fearr leat ón Premier League."
 
 #. Answer option
 msgctxt "{number_of_people} people live here, is this correct?"
@@ -160,3 +180,18 @@ msgstr[5] "Gaelic (other)"
 msgctxt "{number_of_people} people live here, is this correct?"
 msgid "No"
 msgstr "Níl"
+
+#. Answer option
+msgctxt "Which football team do you support?"
+msgid "Liverpool"
+msgstr "Learpholl"
+
+#. Answer option
+msgctxt "Which football team do you support?"
+msgid "Chelsea"
+msgstr "Chelsea"
+
+#. Answer option
+msgctxt "Which football team do you support?"
+msgid "Rugby is better!"
+msgstr "Is fearr rugbaí!"

--- a/tests/schemas/test_language.pot
+++ b/tests/schemas/test_language.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-10-28 08:32+0000\n"
+"POT-Creation-Date: 2020-11-10 12:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -88,6 +88,10 @@ msgid_plural "{number_of_people} people live here, is this correct?"
 msgstr[0] ""
 msgstr[1] ""
 
+#. Question text
+msgid "Which football team do you support?"
+msgstr ""
+
 #. Question description
 msgctxt "Please enter a name"
 msgid "The full name of the person"
@@ -133,10 +137,26 @@ msgctxt "How many people live at your household?"
 msgid "Number of household residents"
 msgstr ""
 
+#. Answer
+msgctxt "Which football team do you support?"
+msgid "Football team"
+msgstr ""
+
+#. Placeholder text used for select field
+msgctxt "Which football team do you support?"
+msgid "Select an option"
+msgstr ""
+
 #. Answer description
 #. For answer: Date of Birth
 msgctxt "What is {person_name_possessive} date of birth?"
 msgid "Enter your date of birth"
+msgstr ""
+
+#. Answer description
+#. For answer: Football team
+msgctxt "Which football team do you support?"
+msgid "Your favourite team from the Premier League."
 msgstr ""
 
 #. Answer option
@@ -149,5 +169,20 @@ msgstr[1] ""
 #. Answer option
 msgctxt "{number_of_people} people live here, is this correct?"
 msgid "No"
+msgstr ""
+
+#. Answer option
+msgctxt "Which football team do you support?"
+msgid "Liverpool"
+msgstr ""
+
+#. Answer option
+msgctxt "Which football team do you support?"
+msgid "Chelsea"
+msgstr ""
+
+#. Answer option
+msgctxt "Which football team do you support?"
+msgid "Rugby is better!"
 msgstr ""
 

--- a/tests/schemas/test_language.pot
+++ b/tests/schemas/test_language.pot
@@ -142,7 +142,7 @@ msgctxt "Which football team do you support?"
 msgid "Football team"
 msgstr ""
 
-#. Placeholder text used for select field
+#. Dropdown field placeholder text
 msgctxt "Which football team do you support?"
 msgid "Select an option"
 msgstr ""


### PR DESCRIPTION
### What is the context of this PR?
Added translation support for `placeholder` introduced by https://github.com/ONSdigital/eq-questionnaire-validator/pull/82

### How to review 
Ensure extraction and translation for `placeholder` works with not side effects.