### PR TITLE
Translate post submission guidance contents

### DIFF
--- a/eq_translations/extractable_strings.py
+++ b/eq_translations/extractable_strings.py
@@ -17,6 +17,7 @@ EXTRACTABLE_STRINGS = [
     {
         "json_path": "$.post_submission.guidance.contents[*].list[*]",
         "description": "Post submission guidance list item",
+        "additional_context": ["ListHeading", "ListDescription"],
     },
     {"json_path": "$.sections[*].title", "description": "Section title"},
     {"json_path": "$..page_title", "description": "Page title"},

--- a/eq_translations/extractable_strings.py
+++ b/eq_translations/extractable_strings.py
@@ -6,6 +6,18 @@ EXTRACTABLE_STRINGS = [
     {"json_path": "$.submission.guidance", "description": "Submission guidance",},
     {"json_path": "$.submission.title", "description": "Submission title"},
     {"json_path": "$.submission.warning", "description": "Submission warning"},
+    {
+        "json_path": "$.post_submission.guidance.contents[*].title",
+        "description": "Post submission guidance heading",
+    },
+    {
+        "json_path": "$.post_submission.guidance.contents[*].description",
+        "description": "Post submission guidance description",
+    },
+    {
+        "json_path": "$.post_submission.guidance.contents[*].list[*]",
+        "description": "Post submission guidance list item",
+    },
     {"json_path": "$.sections[*].title", "description": "Section title"},
     {"json_path": "$..page_title", "description": "Page title"},
     {

--- a/tests/schemas/cy/test_language.json
+++ b/tests/schemas/cy/test_language.json
@@ -26,6 +26,19 @@
         "title": "Teitl cyflwyno",
         "warning": "Rhybudd cyflwyno"
     },
+    "post_submission": {
+        "guidance": {
+            "contents": [
+                {
+                    "title": "Teitl y canllawiau ar \u00f4l cyflwyno",
+                    "description": "Disgrifiad canllaw ar \u00f4l cyflwyno.",
+                    "list": [
+                        "Eitem rhestr canllawiau \u00f4l-gyflwyno"
+                    ]
+                }
+            ]
+        }
+    },
     "sections": [
         {
             "id": "default-section",

--- a/tests/schemas/en/test_language.json
+++ b/tests/schemas/en/test_language.json
@@ -26,6 +26,19 @@
         "title": "Submission title",
         "warning": "Submission warning"
     },
+    "post_submission": {
+        "guidance": {
+            "contents": [
+                {
+                    "title": "Post submission guidance title",
+                    "description": "Post submission guidance description.",
+                    "list": [
+                        "Post submission guidance list item"
+                    ]
+                }
+            ]
+        }
+    },
     "sections": [
         {
             "id": "default-section",

--- a/tests/schemas/test_language-cy.po
+++ b/tests/schemas/test_language-cy.po
@@ -45,6 +45,8 @@ msgid "Post submission guidance description."
 msgstr "Disgrifiad canllaw ar ôl cyflwyno."
 
 #. Post submission guidance list item
+#. For heading: Post submission guidance title
+#. For description: Post submission guidance description.
 msgid "Post submission guidance list item"
 msgstr "Eitem rhestr canllawiau ôl-gyflwyno"
 

--- a/tests/schemas/test_language-cy.po
+++ b/tests/schemas/test_language-cy.po
@@ -36,6 +36,18 @@ msgstr "Teitl cyflwyno"
 msgid "Submission warning"
 msgstr "Rhybudd cyflwyno"
 
+#. Post submission guidance heading
+msgid "Post submission guidance title"
+msgstr "Teitl y canllawiau ar ôl cyflwyno"
+
+#. Post submission guidance description
+msgid "Post submission guidance description."
+msgstr "Disgrifiad canllaw ar ôl cyflwyno."
+
+#. Post submission guidance list item
+msgid "Post submission guidance list item"
+msgstr "Eitem rhestr canllawiau ôl-gyflwyno"
+
 #. Section title
 msgid "Household details"
 msgstr "Manylion y cartref"

--- a/tests/schemas/test_language.pot
+++ b/tests/schemas/test_language.pot
@@ -1,21 +1,21 @@
 # Translations template for PROJECT.
-# Copyright (C) 2020 ORGANIZATION
+# Copyright (C) 2021 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-11-10 12:44+0000\n"
+"POT-Creation-Date: 2021-08-20 14:53+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.8.0\n"
+"Generated-By: Babel 2.9.1\n"
 
 #. Questionnaire title
 msgid "Test Language Survey"
@@ -35,6 +35,18 @@ msgstr ""
 
 #. Submission warning
 msgid "Submission warning"
+msgstr ""
+
+#. Post submission guidance heading
+msgid "Post submission guidance title"
+msgstr ""
+
+#. Post submission guidance description
+msgid "Post submission guidance description."
+msgstr ""
+
+#. Post submission guidance list item
+msgid "Post submission guidance list item"
 msgstr ""
 
 #. Section title

--- a/tests/schemas/test_language.pot
+++ b/tests/schemas/test_language.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-08-20 14:53+0100\n"
+"POT-Creation-Date: 2021-08-23 12:54+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -46,6 +46,8 @@ msgid "Post submission guidance description."
 msgstr ""
 
 #. Post submission guidance list item
+#. For heading: Post submission guidance title
+#. For description: Post submission guidance description.
 msgid "Post submission guidance list item"
 msgstr ""
 


### PR DESCRIPTION
### What is the context of this PR?
Adds the new post submission guidance properties to translations.

### How to review 
Check that the post submission guidance strings are extracted and regeneration of a translated schema contains the strings.
