### PR TITLE
Update setup to support poetry

### DIFF
--- a/eq_translations/__init__.py
+++ b/eq_translations/__init__.py
@@ -1,7 +1,4 @@
 from .schema_translation import SchemaTranslation
 from .survey_schema import SurveySchema
-from setup import __version__
 
-__all__ = ("__version__", "SurveySchema", "SchemaTranslation")
-
-
+__all__ = ("SurveySchema", "SchemaTranslation")

--- a/eq_translations/__init__.py
+++ b/eq_translations/__init__.py
@@ -1,5 +1,4 @@
-from setup import __version__
 from .schema_translation import SchemaTranslation
 from .survey_schema import SurveySchema
 
-__all__ = ("__version__", "SurveySchema", "SchemaTranslation")
+__all__ = ("SurveySchema", "SchemaTranslation")

--- a/eq_translations/__init__.py
+++ b/eq_translations/__init__.py
@@ -1,4 +1,5 @@
+from setup import __version__
 from .schema_translation import SchemaTranslation
 from .survey_schema import SurveySchema
 
-__all__ = ("SurveySchema", "SchemaTranslation")
+__all__ = ("__version__", "SurveySchema", "SchemaTranslation")

--- a/eq_translations/__init__.py
+++ b/eq_translations/__init__.py
@@ -1,6 +1,7 @@
 from .schema_translation import SchemaTranslation
 from .survey_schema import SurveySchema
+from setup import __version__
 
 __all__ = ("__version__", "SurveySchema", "SchemaTranslation")
 
-__version__ = "4.6.0"
+

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,12 @@
 from setuptools import setup
-from eq_translations import __version__
+
+__version__ = "4.6.1"
 
 setup(
     name="eq_translations",
-    version="4.6.1",
+    version=__version__,
     description="Translations infrastructure for EQ Questionnaire Runner",
-    url="http://github.com/ONSDigital/eq-translations",
+    url="http://github.com/ONSdigital/eq-translations",
     author="ONSDigital",
     author_email="",
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
-
-__version__ = "4.6.1"
+from eq_translations.version import __version__
+# __version__ = "4.6.1"
 
 setup(
     name="eq_translations",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
-from eq_translations.version import __version__
-# __version__ = "4.6.1"
+
+__version__ = "4.6.1"
 
 setup(
     name="eq_translations",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from eq_translations import __version__
 
 setup(
     name="eq_translations",
-    version=__version__,
+    version="4.6.1",
     description="Translations infrastructure for EQ Questionnaire Runner",
     url="http://github.com/ONSDigital/eq-translations",
     author="ONSDigital",


### PR DESCRIPTION
### What is the context of this PR?
Poetry fails to install this package due to version not being found. Currently it is imported statement which is causing the issue. Version no is now explicitly mentioned in setuptools.py so poetry can pick it up.
companion [Validator PR](https://github.com/ONSdigital/eq-questionnaire-validator/pull/136) 

### How to review 
Check if poetry ( in validator) is able to install this package using branch name
_eq-translations = {git = "https://github.com/ONSDigital/eq-translations.git", rev = "update-setup-to-support-poetry"}_