### PR TITLE
Add introduction schema element to translatable items list 

### DIFF
--- a/eq_translations/extractable_strings.py
+++ b/eq_translations/extractable_strings.py
@@ -301,18 +301,18 @@ EXTRACTABLE_STRINGS = [
     {
         "json_path": "$..secondary_content[*].contents[*].list[*]",
         "description": "Introduction additional list item",
-        "context": "SecondaryListHeading",
-        "additional_context": ["SecondaryListDescription"],
+        "context": "ListHeading",
+        "additional_context": ["ListDescription"],
     },
     {
         "json_path": "$..secondary_content[*].contents[*].description",
         "description": "Introduction additional description",
-        "context": "SecondaryListHeading",
+        "context": "ListHeading",
     },
     {
         "json_path": "$..secondary_content[*].description",
         "description": "Introduction additional description",
-        "context": "SecondaryListHeading",
+        "context": "ListHeading",
     },
 ]
 
@@ -361,15 +361,5 @@ CONTEXT_DEFINITIONS = {
         "parent_schema_property": "questions",
         "property": "question",
         "text": "For question: {context}",
-    },
-    "SecondaryListHeading": {
-        "parent_schema_property": "secondary_content",
-        "property": "title",
-        "text": "For heading: {context}",
-    },
-    "SecondaryListDescription": {
-        "parent_schema_property": "secondary_content",
-        "property": "description",
-        "text": "For description: {context}",
     },
 }

--- a/eq_translations/extractable_strings.py
+++ b/eq_translations/extractable_strings.py
@@ -267,7 +267,6 @@ EXTRACTABLE_STRINGS = [
     {
         "json_path": "$..preview_content.title",
         "description": "Introduction preview content title",
-        "context": "PreviewContent",
     },
     {
         "json_path": "$..preview_content.contents[*].description",

--- a/eq_translations/extractable_strings.py
+++ b/eq_translations/extractable_strings.py
@@ -295,6 +295,10 @@ EXTRACTABLE_STRINGS = [
         "description": "Introduction additional title",
     },
     {
+        "json_path": "$..secondary_content[*].title",
+        "description": "Introduction additional title",
+    },
+    {
         "json_path": "$..secondary_content[*].contents[*].list[*]",
         "description": "Introduction additional list item",
         "context": "SecondaryListHeading",
@@ -302,6 +306,11 @@ EXTRACTABLE_STRINGS = [
     },
     {
         "json_path": "$..secondary_content[*].contents[*].description",
+        "description": "Introduction additional description",
+        "context": "SecondaryListHeading",
+    },
+    {
+        "json_path": "$..secondary_content[*].description",
         "description": "Introduction additional description",
         "context": "SecondaryListHeading",
     },

--- a/eq_translations/extractable_strings.py
+++ b/eq_translations/extractable_strings.py
@@ -239,6 +239,71 @@ EXTRACTABLE_STRINGS = [
         "context": "Question",
         "additional_context": ["ListHeading", "ListDescription"],
     },
+    {
+        "json_path": "$..primary_content[*].title",
+        "description": "Introduction primary content",
+        "context": "PrimaryContent",
+    },
+    {
+        "json_path": "$..primary_content[*].contents[*].list[*]",
+        "description": "Introduction primary content list item",
+        "context": "PrimaryContent",
+        "additional_context": ["ListHeading", "ListDescription"],
+    },
+    {
+        "json_path": "$..primary_content[*].contents[*].description",
+        "description": "Introduction primary content description",
+        "context": "PrimaryContent",
+    },
+    {
+        "json_path": "$..primary_content[*].contents[*].guidance.contents[*].title",
+        "description": "Introduction primary content guidance title",
+        "context": "PrimaryContent",
+    },
+    {
+        "json_path": "$..primary_content[*].contents[*].guidance.contents[*].description",
+        "description": "Introduction primary content guidance description",
+        "context": "PrimaryContent",
+    },
+    {
+        "json_path": "$..preview_content.title",
+        "description": "Introduction preview content title",
+        "context": "PreviewContent",
+    },
+    {
+        "json_path": "$..preview_content.contents[*].description",
+        "description": "Introduction preview content description",
+        "context": "PreviewContent",
+    },
+    {
+        "json_path": "$..preview_content.questions[*].question",
+        "description": "Introduction preview content question title",
+        "context": "PreviewContent",
+    },
+    {
+        "json_path": "$..preview_content.questions[*].contents[*].description",
+        "description": "Introduction preview question content description",
+        "context": "PreviewContent",
+        "additional_context": ["PreviewQuestionListHeading"],
+    },
+    {
+        "json_path": "$..preview_content.questions[*].contents[*].list[*]",
+        "description": "Introduction preview question list item",
+        "context": "PreviewContent",
+        "additional_context": ["PreviewQuestionListHeading"],
+    },
+    {
+        "json_path": "$..secondary_content[*].contents[*].title",
+        "description": "Introduction secondary content contents title",
+    },
+    {
+        "json_path": "$..secondary_content[*].contents[*].list[*]",
+        "description": "Introduction secondary content contents list item",
+    },
+    {
+        "json_path": "$..secondary_content[*].contents[*].description",
+        "description": "Introduction secondary content contents description",
+    },
 ]
 
 CONTEXT_DEFINITIONS = {
@@ -271,5 +336,20 @@ CONTEXT_DEFINITIONS = {
         "parent_schema_property": "contents",
         "property": "description",
         "text": "For description: {context}",
+    },
+    "PrimaryContent": {
+        "parent_schema_property": "primary_content",
+        "property": "title",
+        "text": "{context}",
+    },
+    "PreviewContent": {
+        "parent_schema_property": "preview_content",
+        "property": "title",
+        "text": "{context}",
+    },
+    "PreviewQuestionListHeading": {
+        "parent_schema_property": "questions",
+        "property": "question",
+        "text": "For question: {context}",
     },
 }

--- a/eq_translations/extractable_strings.py
+++ b/eq_translations/extractable_strings.py
@@ -242,7 +242,6 @@ EXTRACTABLE_STRINGS = [
     {
         "json_path": "$..primary_content[*].title",
         "description": "Introduction primary content",
-        "context": "PrimaryContent",
     },
     {
         "json_path": "$..primary_content[*].contents[*].list[*]",

--- a/eq_translations/extractable_strings.py
+++ b/eq_translations/extractable_strings.py
@@ -241,46 +241,46 @@ EXTRACTABLE_STRINGS = [
     },
     {
         "json_path": "$..primary_content[*].title",
-        "description": "Introduction primary content",
+        "description": "Introduction main title",
     },
     {
         "json_path": "$..primary_content[*].contents[*].list[*]",
-        "description": "Introduction primary content list item",
+        "description": "Introduction main list item",
         "context": "PrimaryContent",
         "additional_context": ["ListHeading", "ListDescription"],
     },
     {
         "json_path": "$..primary_content[*].contents[*].description",
-        "description": "Introduction primary content description",
+        "description": "Introduction main description",
         "context": "PrimaryContent",
     },
     {
         "json_path": "$..primary_content[*].contents[*].guidance.contents[*].title",
-        "description": "Introduction primary content guidance title",
+        "description": "Introduction main guidance title",
         "context": "PrimaryContent",
     },
     {
         "json_path": "$..primary_content[*].contents[*].guidance.contents[*].description",
-        "description": "Introduction primary content guidance description",
+        "description": "Introduction main guidance description",
         "context": "PrimaryContent",
     },
     {
         "json_path": "$..preview_content.title",
-        "description": "Introduction preview content title",
+        "description": "Introduction preview title",
     },
     {
         "json_path": "$..preview_content.contents[*].description",
-        "description": "Introduction preview content description",
+        "description": "Introduction preview description",
         "context": "PreviewContent",
     },
     {
         "json_path": "$..preview_content.questions[*].question",
-        "description": "Introduction preview content question title",
+        "description": "Introduction preview question title",
         "context": "PreviewContent",
     },
     {
         "json_path": "$..preview_content.questions[*].contents[*].description",
-        "description": "Introduction preview question content description",
+        "description": "Introduction preview question description",
         "context": "PreviewContent",
         "additional_context": ["PreviewQuestionListHeading"],
     },
@@ -292,15 +292,15 @@ EXTRACTABLE_STRINGS = [
     },
     {
         "json_path": "$..secondary_content[*].contents[*].title",
-        "description": "Introduction secondary content contents title",
+        "description": "Introduction additional title",
     },
     {
         "json_path": "$..secondary_content[*].contents[*].list[*]",
-        "description": "Introduction secondary content contents list item",
+        "description": "Introduction additional list item",
     },
     {
         "json_path": "$..secondary_content[*].contents[*].description",
-        "description": "Introduction secondary content contents description",
+        "description": "Introduction additional description",
     },
 ]
 

--- a/eq_translations/extractable_strings.py
+++ b/eq_translations/extractable_strings.py
@@ -263,6 +263,13 @@ EXTRACTABLE_STRINGS = [
         "json_path": "$..primary_content[*].contents[*].guidance.contents[*].description",
         "description": "Introduction main guidance description",
         "context": "PrimaryContent",
+        "additional_context": ["ListHeading"],
+    },
+    {
+        "json_path": "$..primary_content[*].contents[*].guidance.contents[*].list[*]",
+        "description": "Introduction main guidance list",
+        "context": "PrimaryContent",
+        "additional_context": ["ListHeading"],
     },
     {
         "json_path": "$..preview_content.title",

--- a/eq_translations/extractable_strings.py
+++ b/eq_translations/extractable_strings.py
@@ -297,10 +297,13 @@ EXTRACTABLE_STRINGS = [
     {
         "json_path": "$..secondary_content[*].contents[*].list[*]",
         "description": "Introduction additional list item",
+        "context": "ListHeading",
+        "additional_context": ["ListDescription"],
     },
     {
         "json_path": "$..secondary_content[*].contents[*].description",
         "description": "Introduction additional description",
+        "context": "ListHeading",
     },
 ]
 

--- a/eq_translations/extractable_strings.py
+++ b/eq_translations/extractable_strings.py
@@ -295,10 +295,6 @@ EXTRACTABLE_STRINGS = [
         "description": "Introduction additional title",
     },
     {
-        "json_path": "$..secondary_content[*].title",
-        "description": "Introduction additional title",
-    },
-    {
         "json_path": "$..secondary_content[*].contents[*].list[*]",
         "description": "Introduction additional list item",
         "context": "ListHeading",
@@ -306,11 +302,6 @@ EXTRACTABLE_STRINGS = [
     },
     {
         "json_path": "$..secondary_content[*].contents[*].description",
-        "description": "Introduction additional description",
-        "context": "ListHeading",
-    },
-    {
-        "json_path": "$..secondary_content[*].description",
         "description": "Introduction additional description",
         "context": "ListHeading",
     },

--- a/eq_translations/extractable_strings.py
+++ b/eq_translations/extractable_strings.py
@@ -297,13 +297,13 @@ EXTRACTABLE_STRINGS = [
     {
         "json_path": "$..secondary_content[*].contents[*].list[*]",
         "description": "Introduction additional list item",
-        "context": "ListHeading",
-        "additional_context": ["ListDescription"],
+        "context": "SecondaryListHeading",
+        "additional_context": ["SecondaryListDescription"],
     },
     {
         "json_path": "$..secondary_content[*].contents[*].description",
         "description": "Introduction additional description",
-        "context": "ListHeading",
+        "context": "SecondaryListHeading",
     },
 ]
 
@@ -352,5 +352,15 @@ CONTEXT_DEFINITIONS = {
         "parent_schema_property": "questions",
         "property": "question",
         "text": "For question: {context}",
+    },
+    "SecondaryListHeading": {
+        "parent_schema_property": "secondary_content",
+        "property": "title",
+        "text": "For heading: {context}",
+    },
+    "SecondaryListDescription": {
+        "parent_schema_property": "secondary_content",
+        "property": "description",
+        "text": "For description: {context}",
     },
 }

--- a/tests/test_survey_schema_extraction.py
+++ b/tests/test_survey_schema_extraction.py
@@ -799,7 +799,6 @@ def test_introduction():
             pointer="/primary_content/0/title/text",
             description="Introduction primary content",
             value="You are completing this for ESSENTIAL ENTERPRISE LTD.",
-            context="You are completing this for ESSENTIAL ENTERPRISE LTD.",
         )
         in translatable_items
     )
@@ -838,7 +837,6 @@ def test_introduction():
             pointer="/preview_content/title",
             description="Introduction preview content title",
             value="Information you need",
-            context="Information you need",
         )
         in translatable_items
     )

--- a/tests/test_survey_schema_extraction.py
+++ b/tests/test_survey_schema_extraction.py
@@ -900,7 +900,7 @@ def test_introduction():
             value="You cannot appeal your selection. Your business was selected to give us a comprehensive view of the "
             "UK economy.",
             context="For heading: How we use your data",
-            additional_context=["For description: Introduction example description"]
+            additional_context=["For description: Introduction example description"],
         )
         in translatable_items
     )

--- a/tests/test_survey_schema_extraction.py
+++ b/tests/test_survey_schema_extraction.py
@@ -900,7 +900,7 @@ def test_introduction():
             pointer="/secondary_content/0/contents/2/list/0",
             description="Introduction additional list item",
             value="You cannot appeal your selection. Your business was selected to give us a comprehensive view of the "
-                  "UK economy.",
+            "UK economy.",
         )
         in translatable_items
     )

--- a/tests/test_survey_schema_extraction.py
+++ b/tests/test_survey_schema_extraction.py
@@ -738,7 +738,21 @@ def test_introduction():
                             "text": "If the company details or structure have changed contact us on 0300 1234 931 or em"
                             "ail"
                         }
-                    }
+                    },
+                    {
+                        "guidance": {
+                            "contents": [
+                                {"title": "Employees"},
+                                {"description": "Include:"},
+                                {
+                                    "list": [
+                                        "all employees in Great Britain (England, Scotland and Wales)",
+                                    ]
+                                },
+                                {"description": "<strong>Exclude:</strong>"},
+                            ]
+                        },
+                    },
                 ],
             },
             {
@@ -829,6 +843,36 @@ def test_introduction():
             description="Introduction main description",
             value="<strong>If you have closed for all, or some, of the period</strong>: select yes, you can provide fig"
             "ures and enter retail turnover.",
+        )
+        in translatable_items
+    )
+
+    assert (
+        TranslatableItem(
+            pointer="/primary_content/0/contents/1/guidance/contents/0/title",
+            description="Introduction main guidance title",
+            value="Employees",
+            context="You are completing this for ESSENTIAL ENTERPRISE LTD.",
+        )
+        in translatable_items
+    )
+
+    assert (
+        TranslatableItem(
+            pointer="/primary_content/0/contents/1/guidance/contents/1/description",
+            description="Introduction main guidance description",
+            value="Include:",
+            context="You are completing this for ESSENTIAL ENTERPRISE LTD.",
+        )
+        in translatable_items
+    )
+
+    assert (
+        TranslatableItem(
+            pointer="/primary_content/0/contents/1/guidance/contents/2/list/0",
+            description="Introduction main guidance list",
+            value="all employees in Great Britain (England, Scotland and Wales)",
+            context="You are completing this for ESSENTIAL ENTERPRISE LTD.",
         )
         in translatable_items
     )

--- a/tests/test_survey_schema_extraction.py
+++ b/tests/test_survey_schema_extraction.py
@@ -797,7 +797,7 @@ def test_introduction():
     assert (
         TranslatableItem(
             pointer="/primary_content/0/title/text",
-            description="Introduction primary content",
+            description="Introduction main title",
             value="You are completing this for ESSENTIAL ENTERPRISE LTD.",
         )
         in translatable_items
@@ -806,7 +806,7 @@ def test_introduction():
     assert (
         TranslatableItem(
             pointer="/primary_content/1/contents/0/list/0",
-            description="Introduction primary content list item",
+            description="Introduction main list item",
             value="On average it takes 10 minutes to complete this survey once you have collected the information.",
         )
         in translatable_items
@@ -815,7 +815,7 @@ def test_introduction():
     assert (
         TranslatableItem(
             pointer="/primary_content/0/contents/0/description/text",
-            description="Introduction primary content description",
+            description="Introduction main description",
             value="If the company details or structure have changed contact us on 0300 1234 931 or email",
             context="You are completing this for ESSENTIAL ENTERPRISE LTD.",
         )
@@ -825,7 +825,7 @@ def test_introduction():
     assert (
         TranslatableItem(
             pointer="/primary_content/1/contents/1/description",
-            description="Introduction primary content description",
+            description="Introduction main description",
             value="<strong>If you have closed for all, or some, of the period</strong>: select yes, you can provide fig"
             "ures and enter retail turnover.",
         )
@@ -835,7 +835,7 @@ def test_introduction():
     assert (
         TranslatableItem(
             pointer="/preview_content/title",
-            description="Introduction preview content title",
+            description="Introduction preview title",
             value="Information you need",
         )
         in translatable_items
@@ -844,7 +844,7 @@ def test_introduction():
     assert (
         TranslatableItem(
             pointer="/preview_content/contents/0/description",
-            description="Introduction preview content description",
+            description="Introduction preview description",
             value="<a href=''>View the survey information before you start the survey</a>",
             context="Information you need",
         )
@@ -854,7 +854,7 @@ def test_introduction():
     assert (
         TranslatableItem(
             pointer="/preview_content/questions/0/question",
-            description="Introduction preview content question title",
+            description="Introduction preview question title",
             value="Total retail turnover",
             context="Information you need",
         )
@@ -864,7 +864,7 @@ def test_introduction():
     assert (
         TranslatableItem(
             pointer="/preview_content/questions/0/contents/0/description",
-            description="Introduction preview question content description",
+            description="Introduction preview question description",
             value="<strong>Include:</strong>",
             context="Information you need",
             additional_context=["For question: Total retail turnover"],
@@ -886,7 +886,7 @@ def test_introduction():
     assert (
         TranslatableItem(
             pointer="/secondary_content/0/contents/0/title",
-            description="Introduction secondary content contents title",
+            description="Introduction additional title",
             value="How we use your data",
         )
         in translatable_items
@@ -895,7 +895,7 @@ def test_introduction():
     assert (
         TranslatableItem(
             pointer="/secondary_content/0/contents/1/list/0",
-            description="Introduction secondary content contents list item",
+            description="Introduction additional list item",
             value="You cannot appeal your selection. Your business was selected to give us a comprehensive view of the "
             "UK economy.",
         )

--- a/tests/test_survey_schema_extraction.py
+++ b/tests/test_survey_schema_extraction.py
@@ -778,8 +778,14 @@ def test_introduction():
         "secondary_content": [
             {
                 "id": "secondary-content",
+                "title": {
+                    "text": "How we use your data",
+                },
+                "description": {
+                    "text": "Introduction example description"
+                },
                 "contents": [
-                    {"title": "How we use your data"},
+
                     {
                         "list": [
                             "You cannot appeal your selection. Your business was selected to give us a comprehensive vi"
@@ -894,10 +900,12 @@ def test_introduction():
 
     assert (
         TranslatableItem(
-            pointer="/secondary_content/0/contents/1/list/0",
+            pointer="/secondary_content/0/contents/0/list/0",
             description="Introduction additional list item",
             value="You cannot appeal your selection. Your business was selected to give us a comprehensive view of the "
             "UK economy.",
+            context="For heading: How we use your data",
+            additional_context=["For description: Introduction example description"]
         )
         in translatable_items
     )

--- a/tests/test_survey_schema_extraction.py
+++ b/tests/test_survey_schema_extraction.py
@@ -778,11 +778,11 @@ def test_introduction():
         "secondary_content": [
             {
                 "id": "secondary-content",
-                "title": {
-                    "text": "How we use your data",
-                },
-                "description": {"text": "Introduction example description"},
                 "contents": [
+                    {
+                        "title": {"text": "How we use your data"},
+                    },
+                    {"description": {"text": "Introduction example description"}},
                     {
                         "list": [
                             "You cannot appeal your selection. Your business was selected to give us a comprehensive vi"
@@ -888,7 +888,7 @@ def test_introduction():
 
     assert (
         TranslatableItem(
-            pointer="/secondary_content/0/title/text",
+            pointer="/secondary_content/0/contents/0/title/text",
             description="Introduction additional title",
             value="How we use your data",
         )
@@ -897,12 +897,10 @@ def test_introduction():
 
     assert (
         TranslatableItem(
-            pointer="/secondary_content/0/contents/0/list/0",
+            pointer="/secondary_content/0/contents/2/list/0",
             description="Introduction additional list item",
             value="You cannot appeal your selection. Your business was selected to give us a comprehensive view of the "
-            "UK economy.",
-            context="For heading: How we use your data",
-            additional_context=["For description: Introduction example description"],
+                  "UK economy.",
         )
         in translatable_items
     )

--- a/tests/test_survey_schema_extraction.py
+++ b/tests/test_survey_schema_extraction.py
@@ -781,11 +781,8 @@ def test_introduction():
                 "title": {
                     "text": "How we use your data",
                 },
-                "description": {
-                    "text": "Introduction example description"
-                },
+                "description": {"text": "Introduction example description"},
                 "contents": [
-
                     {
                         "list": [
                             "You cannot appeal your selection. Your business was selected to give us a comprehensive vi"

--- a/tests/test_survey_schema_extraction.py
+++ b/tests/test_survey_schema_extraction.py
@@ -780,14 +780,12 @@ def test_introduction():
                 "id": "secondary-content",
                 "contents": [
                     {
-                        "title": {"text": "How we use your data"},
-                    },
-                    {"description": {"text": "Introduction example description"}},
-                    {
+                        "title": "How we use your data",
+                        "description": "Introduction example description",
                         "list": [
                             "You cannot appeal your selection. Your business was selected to give us a comprehensive vi"
                             "ew of the UK economy."
-                        ]
+                        ],
                     },
                 ],
             }
@@ -888,7 +886,7 @@ def test_introduction():
 
     assert (
         TranslatableItem(
-            pointer="/secondary_content/0/contents/0/title/text",
+            pointer="/secondary_content/0/contents/0/title",
             description="Introduction additional title",
             value="How we use your data",
         )
@@ -897,10 +895,22 @@ def test_introduction():
 
     assert (
         TranslatableItem(
-            pointer="/secondary_content/0/contents/2/list/0",
+            pointer="/secondary_content/0/contents/0/list/0",
             description="Introduction additional list item",
             value="You cannot appeal your selection. Your business was selected to give us a comprehensive view of the "
-            "UK economy.",
+                  "UK economy.",
+            context='For heading: How we use your data',
+            additional_context=['For description: Introduction example description']
+        )
+        in translatable_items
+    )
+
+    assert (
+        TranslatableItem(
+            pointer="/secondary_content/0/contents/0/description",
+            description="Introduction additional description",
+            value="Introduction example description",
+            context='For heading: How we use your data',
         )
         in translatable_items
     )

--- a/tests/test_survey_schema_extraction.py
+++ b/tests/test_survey_schema_extraction.py
@@ -888,7 +888,7 @@ def test_introduction():
 
     assert (
         TranslatableItem(
-            pointer="/secondary_content/0/contents/0/title",
+            pointer="/secondary_content/0/title/text",
             description="Introduction additional title",
             value="How we use your data",
         )

--- a/tests/test_survey_schema_extraction.py
+++ b/tests/test_survey_schema_extraction.py
@@ -720,3 +720,186 @@ def test_all_pointers_resolve_to_correct_instance():
             assert isinstance(translatable_item.value, dict)
         else:
             assert isinstance(translatable_item.value, str)
+
+
+def test_introduction():
+    introduction_block = {
+        "id": "introduction-block",
+        "type": "Introduction",
+        "primary_content": [
+            {
+                "id": "primary",
+                "title": {
+                    "text": "You are completing this for ESSENTIAL ENTERPRISE LTD."
+                },
+                "contents": [
+                    {
+                        "description": {
+                            "text": "If the company details or structure have changed contact us on 0300 1234 931 or em"
+                            "ail"
+                        }
+                    }
+                ],
+            },
+            {
+                "id": "description",
+                "contents": [
+                    {
+                        "list": [
+                            "On average it takes 10 minutes to complete this survey once you have collected the informa"
+                            "tion."
+                        ]
+                    },
+                    {
+                        "description": "<strong>If you have closed for all, or some, of the period</strong>: select yes"
+                        ", you can provide figures and enter retail turnover."
+                    },
+                ],
+            },
+        ],
+        "preview_content": {
+            "id": "preview",
+            "title": "Information you need",
+            "contents": [
+                {
+                    "description": "<a href=''>View the survey information before you start the survey</a>"
+                }
+            ],
+            "questions": [
+                {
+                    "question": "Total retail turnover",
+                    "contents": [
+                        {"description": "<strong>Include:</strong>"},
+                        {"list": ["VAT"]},
+                    ],
+                }
+            ],
+        },
+        "secondary_content": [
+            {
+                "id": "secondary-content",
+                "contents": [
+                    {"title": "How we use your data"},
+                    {
+                        "list": [
+                            "You cannot appeal your selection. Your business was selected to give us a comprehensive vi"
+                            "ew of the UK economy."
+                        ]
+                    },
+                ],
+            }
+        ],
+    }
+
+    schema = SurveySchema(introduction_block)
+    translatable_items = list(schema.translatable_items)
+
+    assert (
+        TranslatableItem(
+            pointer="/primary_content/0/title/text",
+            description="Introduction primary content",
+            value="You are completing this for ESSENTIAL ENTERPRISE LTD.",
+            context="You are completing this for ESSENTIAL ENTERPRISE LTD.",
+        )
+        in translatable_items
+    )
+
+    assert (
+        TranslatableItem(
+            pointer="/primary_content/1/contents/0/list/0",
+            description="Introduction primary content list item",
+            value="On average it takes 10 minutes to complete this survey once you have collected the information.",
+        )
+        in translatable_items
+    )
+
+    assert (
+        TranslatableItem(
+            pointer="/primary_content/0/contents/0/description/text",
+            description="Introduction primary content description",
+            value="If the company details or structure have changed contact us on 0300 1234 931 or email",
+            context="You are completing this for ESSENTIAL ENTERPRISE LTD.",
+        )
+        in translatable_items
+    )
+
+    assert (
+        TranslatableItem(
+            pointer="/primary_content/1/contents/1/description",
+            description="Introduction primary content description",
+            value="<strong>If you have closed for all, or some, of the period</strong>: select yes, you can provide fig"
+            "ures and enter retail turnover.",
+        )
+        in translatable_items
+    )
+
+    assert (
+        TranslatableItem(
+            pointer="/preview_content/title",
+            description="Introduction preview content title",
+            value="Information you need",
+            context="Information you need",
+        )
+        in translatable_items
+    )
+
+    assert (
+        TranslatableItem(
+            pointer="/preview_content/contents/0/description",
+            description="Introduction preview content description",
+            value="<a href=''>View the survey information before you start the survey</a>",
+            context="Information you need",
+        )
+        in translatable_items
+    )
+
+    assert (
+        TranslatableItem(
+            pointer="/preview_content/questions/0/question",
+            description="Introduction preview content question title",
+            value="Total retail turnover",
+            context="Information you need",
+        )
+        in translatable_items
+    )
+
+    assert (
+        TranslatableItem(
+            pointer="/preview_content/questions/0/contents/0/description",
+            description="Introduction preview question content description",
+            value="<strong>Include:</strong>",
+            context="Information you need",
+            additional_context=["For question: Total retail turnover"],
+        )
+        in translatable_items
+    )
+
+    assert (
+        TranslatableItem(
+            pointer="/preview_content/questions/0/contents/1/list/0",
+            description="Introduction preview question list item",
+            value="VAT",
+            context="Information you need",
+            additional_context=["For question: Total retail turnover"],
+        )
+        in translatable_items
+    )
+
+    assert (
+        TranslatableItem(
+            pointer="/secondary_content/0/contents/0/title",
+            description="Introduction secondary content contents title",
+            value="How we use your data",
+        )
+        in translatable_items
+    )
+
+    assert (
+        TranslatableItem(
+            pointer="/secondary_content/0/contents/1/list/0",
+            description="Introduction secondary content contents list item",
+            value="You cannot appeal your selection. Your business was selected to give us a comprehensive view of the "
+            "UK economy.",
+        )
+        in translatable_items
+    )

--- a/tests/test_survey_schema_extraction.py
+++ b/tests/test_survey_schema_extraction.py
@@ -902,7 +902,7 @@ def test_introduction():
             value="You cannot appeal your selection. Your business was selected to give us a comprehensive view of the "
             "UK economy.",
             context="For heading: How we use your data",
-            additional_context=["For description: Introduction example description"]
+            additional_context=["For description: Introduction example description"],
         )
         in translatable_items
     )

--- a/tests/test_survey_schema_extraction.py
+++ b/tests/test_survey_schema_extraction.py
@@ -898,9 +898,9 @@ def test_introduction():
             pointer="/secondary_content/0/contents/0/list/0",
             description="Introduction additional list item",
             value="You cannot appeal your selection. Your business was selected to give us a comprehensive view of the "
-                  "UK economy.",
-            context='For heading: How we use your data',
-            additional_context=['For description: Introduction example description']
+            "UK economy.",
+            context="For heading: How we use your data",
+            additional_context=["For description: Introduction example description"]
         )
         in translatable_items
     )
@@ -910,7 +910,7 @@ def test_introduction():
             pointer="/secondary_content/0/contents/0/description",
             description="Introduction additional description",
             value="Introduction example description",
-            context='For heading: How we use your data',
+            context="For heading: How we use your data",
         )
         in translatable_items
     )


### PR DESCRIPTION
### What is the context of this PR?
Adds introduction block to translatable strings, some context added for the less obvious elements like question preview description.

### How to review 
You need to run extract script followed by translate schema one. Best if you create .po file from generate .pot file and do translations manually to test.
