### PR TITLE
Add item_label to extractable summary strings

### DIFF
--- a/eq_translations/extractable_strings.py
+++ b/eq_translations/extractable_strings.py
@@ -44,6 +44,10 @@ EXTRACTABLE_STRINGS = [
         "json_path": "$.sections[*].summary.items[*].empty_list_text",
         "description": "Section summary empty list text",
     },
+    {
+        "json_path": "$.sections[*].summary.items[*].item_label",
+        "description": "Label for the item title on a list summary",
+    },
     {"json_path": "$..groups[*].title", "description": "Group title"},
     {"json_path": "$..blocks[*].title", "description": "Block title"},
     {"json_path": "$..summary.title", "description": "List collector summary heading"},
@@ -58,6 +62,10 @@ EXTRACTABLE_STRINGS = [
     {
         "json_path": "$..summary.add_link_text",
         "description": "List collector add link text",
+    },
+    {
+        "json_path": "$..summary.item_label",
+        "description": "List collector item label",
     },
     {
         "json_path": "$..add_block.cancel_text",

--- a/eq_translations/extractable_strings.py
+++ b/eq_translations/extractable_strings.py
@@ -46,7 +46,7 @@ EXTRACTABLE_STRINGS = [
     },
     {
         "json_path": "$.sections[*].summary.items[*].item_label",
-        "description": "Label for the item title on a list summary",
+        "description": "Label for the item title on a section summary",
     },
     {"json_path": "$..groups[*].title", "description": "Group title"},
     {"json_path": "$..blocks[*].title", "description": "Block title"},

--- a/tests/test_survey_schema_extraction.py
+++ b/tests/test_survey_schema_extraction.py
@@ -701,12 +701,12 @@ def test_summary_without_placeholder_extraction():
         in translatable_items
     )
     assert (
-            TranslatableItem(
-                pointer="/summary/item_label",
-                description="List collector item label",
-                value="List item label",
-            )
-            in translatable_items
+        TranslatableItem(
+            pointer="/summary/item_label",
+            description="List collector item label",
+            value="List item label",
+        )
+        in translatable_items
     )
 
 

--- a/tests/test_survey_schema_extraction.py
+++ b/tests/test_survey_schema_extraction.py
@@ -661,6 +661,7 @@ def test_summary_without_placeholder_extraction():
             "item_title": "A list item",
             "empty_list_text": "An empty title text",
             "add_link_text": "An add link text",
+            "item_label": "List item label",
         }
     }
 
@@ -698,6 +699,14 @@ def test_summary_without_placeholder_extraction():
             value="An add link text",
         )
         in translatable_items
+    )
+    assert (
+            TranslatableItem(
+                pointer="/summary/item_label",
+                description="List collector item label",
+                value="List item label",
+            )
+            in translatable_items
     )
 
 


### PR DESCRIPTION
### What is the context of this PR?

Adds the new summary field `item_label` to the extractable strings list. Needed to support [iteration 1 of looping](https://github.com/ONSdigital/eq-questionnaire-validator/pull/153)

### How to review 
Describe the steps required to test the changes (include screenshots if appropriate).
